### PR TITLE
Implement run with single VCF simulation

### DIFF
--- a/src/main/java/org/monarchinitiative/lr2pg/cmd/SingleVcfSimulator.java
+++ b/src/main/java/org/monarchinitiative/lr2pg/cmd/SingleVcfSimulator.java
@@ -1,0 +1,196 @@
+package org.monarchinitiative.lr2pg.cmd;
+
+import htsjdk.variant.variantcontext.*;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.vcf.VCFHeader;
+import org.monarchinitiative.lr2pg.exception.Lr2PgRuntimeException;
+import org.phenopackets.schema.v1.Phenopacket;
+import org.phenopackets.schema.v1.core.HtsFile;
+import org.phenopackets.schema.v1.core.OntologyClass;
+import org.phenopackets.schema.v1.core.Variant;
+import org.phenopackets.schema.v1.core.VcfAllele;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Simulator that injects variants defined from {@link Phenopacket} among variants present in single VCF file.
+ */
+public class SingleVcfSimulator {
+
+    public static final OntologyClass HET = OntologyClass.newBuilder().setId("GENO:0000135").setLabel("heterozygous").build();
+
+    public static final OntologyClass HOM_ALT = OntologyClass.newBuilder().setId("GENO:0000136").setLabel("homozygous").build();
+
+    public static final OntologyClass HEMIZYGOUS = OntologyClass.newBuilder().setId("GENO:0000134").setLabel("hemizygous").build();
+
+    private static final Pattern INFO_BIFIELD = Pattern.compile("(\\w+)=(-?[\\w.]+)");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SingleVcfSimulator.class);
+
+    private final Path templateVcfPath;
+
+    /**
+     * @param templateVcfPath {@link Path} to possibly un-indexed VCF file
+     */
+    public SingleVcfSimulator(Path templateVcfPath) {
+        this.templateVcfPath = templateVcfPath;
+    }
+
+
+    static VCFHeader updateHeaderWithPhenopacketSample(VCFHeader original, String sampleId) {
+        return new VCFHeader(original.getMetaDataInSortedOrder(), Collections.singleton(sampleId));
+    }
+
+    static UnaryOperator<VariantContext> changeSampleNameInGenotypes(final String sampleId) {
+        return vc -> {
+            final VariantContextBuilder vcb = new VariantContextBuilder(vc)
+                    .noGenotypes() // remove present genotypes and then add updated
+                    .genotypes(vc.getGenotypes().stream()
+                            .map(gt -> new GenotypeBuilder(gt).name(sampleId).make()) // change sample Id on individual genotypes
+                            .collect(Collectors.toList()));
+
+            return vcb.make();
+        };
+    }
+
+    /**
+     * Map {@link Phenopacket} to {@link VariantContext}s. Genotypes in variant contexts are modified so that they
+     * will contain phenopacket subject's id.
+     */
+    private static List<VariantContext> phenopacketToVariantContexts(String subjectId, List<Variant> variants) {
+        List<VariantContext> vcs = new ArrayList<>();
+        for (Variant variant : variants) {
+
+            switch (variant.getAlleleCase()) {
+                case ALLELE_NOT_SET:
+                case SPDI_ALLELE:
+                case ISCN_ALLELE:
+                case HGVS_ALLELE:
+                default:
+                    LOGGER.warn("Variant data are not stored in VCF format, but as {}", variant.getAlleleCase());
+                    continue;
+                case VCF_ALLELE:
+                    // continue execution
+            }
+
+            final VcfAllele vcfAllele = variant.getVcfAllele();
+
+            // here the ref allele is always at 0, alt is at idx 1
+            List<Allele> allAlleles = new ArrayList<>(2);
+            allAlleles.add(Allele.create(vcfAllele.getRef(), true));
+            allAlleles.add(Allele.create(vcfAllele.getAlt()));
+
+            OntologyClass zygosity = variant.getZygosity();
+            GenotypeBuilder genotypeBuilder = new GenotypeBuilder()
+                    .name(subjectId);
+
+            if (zygosity.equals(HET)) {
+                // 1x REF + 1x ALT
+                genotypeBuilder.alleles(Arrays.asList(allAlleles.get(0), allAlleles.get(1)));
+            } else if (zygosity.equals(HOM_ALT)) {
+                // 2x ALT
+                genotypeBuilder.alleles(Arrays.asList(allAlleles.get(1), allAlleles.get(1)));
+            } else if (zygosity.equals(HEMIZYGOUS)) {
+                genotypeBuilder.alleles(Collections.singletonList(allAlleles.get(1)));
+            } else {
+                LOGGER.warn("Unknown genotype '{}'. Tried HET, HOM_ALT, HEMIZYGOUS", zygosity);
+                continue;
+            }
+
+            // INFO fields
+
+            Map<String, Object> infoFields = new HashMap<>();
+            for (String s : vcfAllele.getInfo().split(";")) {
+                Matcher bifield = INFO_BIFIELD.matcher(s);
+                if (bifield.matches()) {
+                    infoFields.put(bifield.group(1), bifield.group(2));
+                } else {
+                    infoFields.put(s, null);
+                }
+            }
+
+            VariantContext vc = new VariantContextBuilder()
+                    // we are working with hg19 usually. Contigs are prepended with 'chr' there
+                    .chr(vcfAllele.getChr().startsWith("chr") ? vcfAllele.getChr() : "chr" + vcfAllele.getChr())
+                    .start(vcfAllele.getPos())
+                    .computeEndFromAlleles(allAlleles, vcfAllele.getPos())
+                    .alleles(allAlleles)
+                    .genotypes(genotypeBuilder.make())
+                    .attributes(infoFields)
+                    .noID()
+                    .make();
+
+            vcs.add(vc);
+        }
+        return vcs;
+    }
+
+    /**
+     *
+     * @param subjectId
+     * @param variants
+     * @return
+     * @throws IOException
+     */
+    public HtsFile simulateVcf(String subjectId, List<Variant> variants, String genomeAssembly) throws IOException {
+        Objects.requireNonNull(subjectId, "Subject ID must not be null");
+        if (subjectId.isEmpty()) {
+            throw new Lr2PgRuntimeException("Subject ID must not be empty");
+        }
+
+        // we create a temporary VCF file for Exomiser analysis
+        final File outPath = File.createTempFile("single-vcf-simulator-" + subjectId + "-", ".vcf");
+        outPath.deleteOnExit();
+
+        try (VCFFileReader reader = new VCFFileReader(templateVcfPath, false);
+             VariantContextWriter writer = new VariantContextWriterBuilder()
+                     .setOutputFile(outPath)
+                     .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF)
+                     .unsetOption(Options.INDEX_ON_THE_FLY)
+                     .setOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER) // important for
+                     .build()) {
+            LOGGER.info("Reading file {}", templateVcfPath);
+            VCFHeader fileHeader = reader.getFileHeader();
+            fileHeader = updateHeaderWithPhenopacketSample(fileHeader, subjectId);
+            writer.writeHeader(fileHeader);
+
+            List<VariantContext> injected = phenopacketToVariantContexts(subjectId, variants);
+
+            AtomicInteger cnt = new AtomicInteger();
+            Stream.concat(reader.iterator().stream(), injected.stream())
+                    .map(changeSampleNameInGenotypes(subjectId))
+                    .sorted(new VariantContextComparator(fileHeader.getContigLines()))
+                    .peek(vc -> cnt.incrementAndGet())
+                    .forEach(writer::add);
+            LOGGER.info("Created VCF containing {} variants", cnt.get());
+        }
+
+        // make description
+        String description = String.format("Simulated VCF file based on a template VCF at '%s'file.", templateVcfPath);
+
+        return HtsFile.newBuilder()
+                .setHtsFormat(HtsFile.HtsFormat.VCF)
+                .setGenomeAssembly(genomeAssembly)
+//                 individual_to_sample_identifiers not set here, this is a naive thing for now
+//                .putAllIndividualToSampleIdentifiers()
+                .setFile(org.phenopackets.schema.v1.core.File.newBuilder()
+                        .setPath(outPath.getAbsolutePath())
+                        .setDescription(description)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/org/monarchinitiative/lr2pg/configuration/Lr2PgFactory.java
+++ b/src/main/java/org/monarchinitiative/lr2pg/configuration/Lr2PgFactory.java
@@ -220,15 +220,20 @@ public class Lr2PgFactory {
     private void initializeExomiserPaths() {
         // Remove the trailing directory slash if any
         this.exomiserPath=getPathWithoutTrailingSeparatorIfPresent(this.exomiserPath);
-        String basename=FilenameUtils.getBaseName(this.exomiserPath);
+//        String basename=FilenameUtils.getBaseName(this.exomiserPath);
+        String basename = "1811_hg19";
         String filename=String.format("%s_variants.mv.db", basename);
-        this.mvStorePath=String.format("%s%s%s", exomiserPath,File.separator,filename);
+//        this.mvStorePath=String.format("%s%s%s", exomiserPath,File.separator,filename);
+        this.mvStorePath = new File(exomiserPath, String.format("%s_variants.mv.db", basename)).getAbsolutePath();
         filename=String.format("%s_transcripts_ucsc.ser", basename);
-        this.jannovarUcscPath=filename;
+//        this.jannovarUcscPath=filename;
+        this.jannovarUcscPath=new File(exomiserPath, String.format("%s_transcripts_ucsc.ser", basename)).getAbsolutePath();
         filename=String.format("%s_transcripts_ensembl.ser", basename);
-        this.jannovarEnsemblPath=filename;
+//        this.jannovarEnsemblPath=filename;
+        this.jannovarEnsemblPath = new File(exomiserPath, String.format("%s_transcripts_ensembl.ser", basename)).getAbsolutePath();
         filename=String.format("%s_transcripts_refseq.ser", basename);
-        this.jannovarRefSeqPath=filename;
+//        this.jannovarRefSeqPath=filename;
+        this.jannovarRefSeqPath=new File(exomiserPath, String.format("%s_transcripts_refseq.ser", basename)).getAbsolutePath();
 
     }
 


### PR DESCRIPTION
Hi @pnrobinson , I've added code that simulates a VCF file based on Phenopacket and a template VCF file. I had to add a new CLI option for `phenopacket` command and the whole command line now looks like this:

```bash
java -jar Lr2pg.jar phenopacket -p /home/ielis/data/lr2pg/casereport_pp/Ajmal-2013-BBS1.json -d /home/ielis/data/lr2pg/data -v /home/ielis/data/eselator-simulations/GIAB/project.NIST.hc.snps.indels.NIST7035.vcf
-e /home/ielis/data/exomiser-data/1811_hg19 
```

**Template VCF file**
There is a new option `-v | --template-vcf` for a VCF file with variants from exome. This is just a naive simulation for now, we could work on more advanced simulation strategies later.

**Phenopacket**
The Phenopacket `Ajmal-2013-BBS1.json` was created by the most recent HpoCaseAnnotator, by using standard Phenopacket export function from file `hrmd/data/casereports/Ajmal-2013-BBS1.json`.

The code compiled and run successfully on my PC. Please review and try if it also works on your side.
Thanks, Daniel 
🗽