### PR TITLE
Coordinate and tweak colors for likelihood ratios

### DIFF
--- a/src/main/java/org/monarchinitiative/lirical/svg/Lirical2Svg.java
+++ b/src/main/java/org/monarchinitiative/lirical/svg/Lirical2Svg.java
@@ -27,7 +27,7 @@ public class Lirical2Svg {
     protected final static String ORANGE = "#ff9900";
     protected final static String BLACK = "#000000";
     protected final static String GREEN = "#00A087";
-
+    protected final static String BRIGHT_GREEN = "#19a000";
 
     protected void writeFooter(Writer writer) throws IOException {
         writer.write("</g>\n</svg>\n");
@@ -64,7 +64,7 @@ public class Lirical2Svg {
     {
         int diamondsize=6;
         writer.write(String.format("<polygon " +
-                        "points=\"%d,%d %d,%d %d,%d %d,%d\" style=\"fill:lime;stroke:%s;stroke-width:1\" />\n",
+                        "points=\"%d,%d %d,%d %d,%d %d,%d\" style=\"fill:grey;stroke:%s;stroke-width:1\" />\n",
                 X,
                 Y,
                 X+diamondsize,

--- a/src/main/java/org/monarchinitiative/lirical/svg/Lr2Svg.java
+++ b/src/main/java/org/monarchinitiative/lirical/svg/Lr2Svg.java
@@ -214,9 +214,9 @@ public class Lr2Svg extends Lirical2Svg {
                 writeDiamond(writer,X,currentY);
             } else {
                 // red for features that do not support the diagnosis, green for those that do
-                String color = xstart<midline ? RED : BLUE;
+                String color = xstart<midline ? RED : BRIGHT_GREEN;
                 writer.write(String.format("<rect height=\"%d\" width=\"%d\" y=\"%d\" x=\"%d\" " +
-                                "stroke-width=\"1\" stroke=\"#000000\" fill=\"%s\"/>\n",
+                                "stroke-width=\"0\" stroke=\"#000000\" fill=\"%s\"/>\n",
                         BOX_HEIGHT,
                         (int) boxwidth,
                         currentY,
@@ -249,9 +249,9 @@ public class Lr2Svg extends Lirical2Svg {
                 writeDiamond(writer,X,currentY);
             } else {
                 // red for features that do not support the diagnosis, green for those that do
-                String color = xstart<midline ? RED : BLUE;
+                String color = xstart<midline ? RED : BRIGHT_GREEN;
                 writer.write(String.format("<rect height=\"%d\" width=\"%d\" y=\"%d\" x=\"%d\" " +
-                                "stroke-width=\"1\" stroke=\"#000000\" fill=\"%s\"/>\n",
+                                "stroke-width=\"0\" stroke=\"#000000\" fill=\"%s\"/>\n",
                         BOX_HEIGHT,
                         (int) boxwidth,
                         currentY,
@@ -287,7 +287,7 @@ public class Lr2Svg extends Lirical2Svg {
                 writeDiamond(writer,X,currentY);
             } else {
                 // red for features that do not support the diagnosis, green for those that do
-                String color = xstart<midline ? RED : BLUE;
+                String color = xstart<midline ? RED : BRIGHT_GREEN;
                 writer.write(String.format("<rect height=\"%d\" width=\"%d\" y=\"%d\" x=\"%d\" " +
                                 "stroke-width=\"1\" stroke=\"#000000\" fill=\"%s\"/>\n",
                         BOX_HEIGHT,

--- a/src/main/java/org/monarchinitiative/lirical/svg/Posttest2Svg.java
+++ b/src/main/java/org/monarchinitiative/lirical/svg/Posttest2Svg.java
@@ -190,7 +190,7 @@ public class Posttest2Svg extends Lirical2Svg {
                         boxwidth,
                         currentY,
                         XSTART,
-                        BLUE));
+                        BRIGHT_GREEN));
             } else {
                 writeDiamond(writer,XSTART,currentY);
             }

--- a/src/main/java/org/monarchinitiative/lirical/svg/Sparkline2Svg.java
+++ b/src/main/java/org/monarchinitiative/lirical/svg/Sparkline2Svg.java
@@ -1,8 +1,6 @@
 package org.monarchinitiative.lirical.svg;
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.util.JsonFormat;
-import org.antlr.v4.runtime.atn.SemanticContext;
 import org.monarchinitiative.lirical.hpo.HpoCase;
 import org.monarchinitiative.lirical.likelihoodratio.TestResult;
 import org.monarchinitiative.phenol.ontology.data.TermId;
@@ -169,7 +167,7 @@ public class Sparkline2Svg extends Lirical2Svg {
             linewidth += BAR_WIDTH + INTERBAR_WIDTH;
         }
         int currentX = xstart + PERCENTAGE_WIDTH + SPACING_WIDTH;
-        swriter.write("<line fill=\"none\" stroke=\"" + RED + "\" stroke-width=\"2\" " +
+        swriter.write("<line fill=\"none\" stroke=\"" + BLACK + "\" stroke-width=\"1\" " +
                 "x1=\"" + currentX + "\" y1=\"" + ybaseline + "\" x2=\"" + (currentX+linewidth) +
                 "\" y2=\"" + ybaseline + "\"/>\n");
         for (int i=0; i<indicesObserved.size(); i++) {
@@ -179,12 +177,12 @@ public class Sparkline2Svg extends Lirical2Svg {
                 int height = (int)(logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 int ypos = ybaseline - height;
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ypos +"\" x=\"" + currentX + "\" " +
-                                "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + BLACK + "\"/>\n");
+                                "stroke-width=\"0\" stroke=\"#000000\" fill=\"" + BRIGHT_GREEN + "\"/>\n");
             } else {
                 logratio = Math.max((-1)*MAX_LOG_LR, logratio);
                 int height = (int)((-1)*logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ybaseline +"\" x=\"" + currentX + "\" " +
-                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + BLACK + "\"/>\n");
+                        "stroke-width=\"0\" stroke=\"#000000\" fill=\"" + RED + "\"/>\n");
             }
             currentX += BAR_WIDTH + INTERBAR_WIDTH;
         }
@@ -195,12 +193,12 @@ public class Sparkline2Svg extends Lirical2Svg {
                 int height = (int)(logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 int ypos = ybaseline - height;
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ypos +"\" x=\"" + currentX + "\" " +
-                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + BLACK + "\"/>\n");
+                        "stroke-width=\"0\" stroke=\"#000000\" fill=\"" + BRIGHT_GREEN + "\"/>\n");
             } else {
                 logratio = Math.max((-1)*MAX_LOG_LR, logratio);
                 int height = (int)((-1)*logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ybaseline +"\" x=\"" + currentX + "\" " +
-                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + BLACK + "\"/>\n");
+                        "stroke-width=\"0\" stroke=\"#000000\" fill=\"" + RED + "\"/>\n");
             }
             currentX += BAR_WIDTH + INTERBAR_WIDTH;
         }
@@ -211,12 +209,12 @@ public class Sparkline2Svg extends Lirical2Svg {
                 int height = (int)(logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 int ypos = ybaseline - height;
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ypos +"\" x=\"" + currentX + "\" " +
-                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + GREEN + "\"/>\n");
+                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + BRIGHT_GREEN + "\"/>\n");
             } else {
                 logratio = Math.max((-1)*MAX_LOG_LR, logratio);
                 int height = (int)((-1)*logratio *(MAXIMUM_BAR_HEIGHT/MAX_LOG_LR));
                 swriter.write("<rect height=\"" + height + "\" width=\"" + BAR_WIDTH + "\" y=\"" + ybaseline +"\" x=\"" + currentX + "\" " +
-                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + GREEN + "\"/>\n");
+                        "stroke-width=\"1\" stroke=\"#000000\" fill=\"" + RED + "\"/>\n");
             }
         }
 
@@ -264,7 +262,7 @@ public class Sparkline2Svg extends Lirical2Svg {
                         "stroke-width=\"1\" stroke=\"#000000\" fill=\"%s\"/>\n",
                 BOX_HEIGHT,
                 barwidth,
-                ORANGE));
+                BRIGHT_GREEN));
     }
 
 }


### PR DESCRIPTION
A few suggested changes to the color scheme. Generally I've changed things so that colors in sparkline graphs and graphs for each disease match, and so that supporting evidence is green and contradicting evidence is red. 

Specifically:
- changed all LRs supporting diagnosis to green, and all LRs contradicting diagnosis to red
(these previously were blue and red respectively)
- removed border around the rect for LRs of phenotypes but preserved border for genotypes, to provide a visual cue that these are different LRs
- changed color of diamond icon for excluded items that neither support nor contradict diagnosis to grey
- changed color of overall disease posterior probability to green (from orange)

Some screenshots with these changes highlighted below. @pnrobinson @jmcmurry What do you guys think? 

![Screen Shot 2019-11-13 at 12 11 41 PM](https://user-images.githubusercontent.com/150311/68800818-a7571680-060f-11ea-8194-d8fa773edef7.png)
![Screen Shot 2019-11-13 at 12 13 18 PM](https://user-images.githubusercontent.com/150311/68800816-a7571680-060f-11ea-91a2-ec9aac27b1bf.png)
![Screen Shot 2019-11-13 at 12 13 42 PM](https://user-images.githubusercontent.com/150311/68800815-a7571680-060f-11ea-8acf-5dd0bab77be8.png)
![Screen Shot 2019-11-13 at 12 11 56 PM](https://user-images.githubusercontent.com/150311/68800817-a7571680-060f-11ea-9041-dd2349c09efb.png)
