### PR TITLE
adding checks that -m and -t cannot be used together and that -t \in [0,1]

### DIFF
--- a/src/main/java/org/monarchinitiative/lirical/cmd/PhenopacketCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/PhenopacketCommand.java
@@ -179,6 +179,7 @@ public class PhenopacketCommand extends PrioritizeCommand {
             logger.error("-p option (phenopacket) is required");
             return;
         }
+        checkThresholds();
         this.metadata = new HashMap<>();
         String hpoPath = String.format("%s%s%s",this.datadir, File.separator,"hp.obo");
         Ontology ontology = OntologyLoader.loadOntology(new File(hpoPath));

--- a/src/main/java/org/monarchinitiative/lirical/cmd/PrioritizeCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/PrioritizeCommand.java
@@ -3,6 +3,7 @@ package org.monarchinitiative.lirical.cmd;
 import com.beust.jcommander.Parameter;
 import org.monarchinitiative.lirical.analysis.Gene2Genotype;
 import org.monarchinitiative.lirical.configuration.LiricalFactory;
+import org.monarchinitiative.lirical.exception.LiricalRuntimeException;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.Map;
@@ -21,12 +22,12 @@ public abstract class PrioritizeCommand extends LiricalCommand {
     @Parameter(names={"-g","--global"}, description = "global analysis")
     protected boolean globalAnalysisMode = false;
     @Parameter(names={"-m","--mindiff"}, description = "minimal number of differential diagnoses to show")
-    protected int minDifferentialsToShow=10;
+    protected Integer minDifferentialsToShow = null;
     @Parameter(names={"-o","--output-directory"}, description = "directory into which to write output file(s).")
     protected String outdir=null;
     /** The threshold for showing a differential diagnosis in the main section (posterior probability of 5%).*/
     @Parameter(names= {"-t","--threshold"}, description = "minimum post-test prob. to show diagnosis in HTML output")
-    protected double LR_THRESHOLD = LiricalFactory.DEFAULT_LR_THRESHOLD;
+    protected Double LR_THRESHOLD = null;
     /** If true, the program will not output an HTML file but will output a Tab Separated Values file instead.*/
     @Parameter(names="--tsv",description = "Use TSV instead of HTML output")
     protected boolean outputTSV=false;
@@ -44,5 +45,18 @@ public abstract class PrioritizeCommand extends LiricalCommand {
     protected Map<TermId, Gene2Genotype> genotypeMap;
     /** Various metadata that will be used for the HTML org.monarchinitiative.lirical.output. */
     protected Map<String,String> metadata;
+
+    protected void checkThresholds() {
+        if (LR_THRESHOLD != null && minDifferentialsToShow != null) {
+            System.err.println("[ERROR] Only one of the options -t/--threshold and -m/--mindiff can be used at once.");
+            throw new LiricalRuntimeException("Only one of the options -t/--threshold and -m/--mindiff can be used at once.");
+        }
+        if (LR_THRESHOLD != null ) {
+            if (LR_THRESHOLD < 0.0 || LR_THRESHOLD > 1.0) {
+                System.err.println("[ERROR] Post-test probability (-t/--threshold) must be between 0.0 and 1.0.");
+                throw new LiricalRuntimeException("Post-test probability (-t/--threshold) must be between 0.0 and 1.0.");
+            }
+        }
+    }
 
 }

--- a/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenopacketCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenopacketCommand.java
@@ -300,6 +300,7 @@ public class SimulatePhenopacketCommand extends PhenopacketCommand {
         detailedResultLineList = new ArrayList<>();
         rank2countMap=new HashMap<>();
         geneRank2CountMap = new HashMap<>();
+        checkThresholds();
         if (phenotypeOnly) {
             runPhenotypeOnly();
         } else {

--- a/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenotypeOnlyCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenotypeOnlyCommand.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
 @Parameters(commandDescription = "Simulate phenotype-only cases",hidden = true)
-public class SimulatePhenotypeOnlyCommand extends LiricalCommand {
+public class SimulatePhenotypeOnlyCommand extends PhenopacketCommand {
     private static final Logger logger = LoggerFactory.getLogger(SimulatePhenotypeOnlyCommand.class);
     /** Directory that contains {@code hp.obo} and {@code phenotype.hpoa} files. */
     @Parameter(names={"-d","--data"}, description ="directory to download data" )
@@ -42,11 +42,12 @@ public class SimulatePhenotypeOnlyCommand extends LiricalCommand {
 
 
     @Override
-    public void run() throws LiricalException {
+    public void run()  {
         LiricalFactory factory = new LiricalFactory.Builder()
                 .datadir(this.datadir)
                 .build();
         factory.qcHumanPhenotypeOntologyFiles();
+        checkThresholds();
         logger.trace("Running simulation with {} cases, {} terms/case, {} noise terms/case. Imprecision: {}",
                 n_cases_to_simulate,n_terms_per_case,n_noise_terms,imprecise_phenotype?"yes":"no");
         Ontology ontology = factory.hpoOntology();
@@ -60,6 +61,10 @@ public class SimulatePhenotypeOnlyCommand extends LiricalCommand {
                 imprecise_phenotype);
         logger.info("Simulating {} cases with {} terms each, {} noise terms. imprecision={}",
             n_cases_to_simulate,n_terms_per_case,n_noise_terms,imprecise_phenotype);
-        phenotypeOnlyHpoCaseSimulator.simulateCases();
+        try {
+            phenotypeOnlyHpoCaseSimulator.simulateCases();
+        } catch (LiricalException e) {
+            e.printStackTrace(); // should never happen, but nothing we can do about it
+        }
     }
 }

--- a/src/main/java/org/monarchinitiative/lirical/cmd/YamlCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/YamlCommand.java
@@ -127,7 +127,6 @@ public class YamlCommand extends LiricalCommand {
     @Override
     public void run() throws LiricalException {
         this.factory = deYamylate(this.yamlPath);
-
         this.ontology =  factory.hpoOntology();
         this.diseaseMap = factory.diseaseMap(ontology);
         this.phenoLr = new PhenotypeLikelihoodRatio(ontology,diseaseMap);

--- a/src/main/java/org/monarchinitiative/lirical/configuration/LiricalFactory.java
+++ b/src/main/java/org/monarchinitiative/lirical/configuration/LiricalFactory.java
@@ -62,8 +62,7 @@ public class LiricalFactory {
     private int n_good_quality_variants=0;
     /** Number of variants that were removed because of the quality filter. */
     private int n_filtered_variants=0;
-    /** LR threshold to include/show a candidate in the differential diagnosis. */
-    private double lrThreshold;
+
     /** Prefix for output files. For example, if outfilePrefix is ABC, then the HTML outfile would be ABC.html.*/
     private String outfilePrefix;
     /** Path to the directory where the output files should be written (by default, this is null and the files are
@@ -73,7 +72,14 @@ public class LiricalFactory {
     /** Default threshold for showing a candidate. */
     public static final double DEFAULT_LR_THRESHOLD = 0.05;
     /** Default number of differentials to show on the HTML output. */
-    public static final  int DEFAULT_MIN_DIFFERENTIALS = 10;
+    public static final int DEFAULT_MIN_DIFFERENTIALS = 10;
+    /** LR threshold to include/show a candidate in the differential diagnosis. This option is incompatible with the
+     * {@link #minDifferentials} option, at most one can be non-null*/
+    private Double lrThreshold;
+    /** Minimum number of differentials to show in detail in the HTML output. This option is incompatible with the
+     * {@link #lrThreshold} option, at most one can be non-null */
+    private Integer minDifferentials;
+
     private static final String DEFAULT_OUTFILE_PREFIX = "lirical";
 
     private final GenomeAssembly assembly;
@@ -107,8 +113,6 @@ public class LiricalFactory {
     private String sampleName="n/a";
 
 
-
-    private int minDifferentials;
 
 
     private JannovarData jannovarData=null;
@@ -170,7 +174,18 @@ public class LiricalFactory {
 
         this.geneInfoPath=builder.geneInfoPath;
         this.mim2genemedgenPath=builder.mim2genemedgenPath;
+        // by the time we get here, we are guaranteed that at once one of the following two
+        // thresholds are non-null (see checkThresholds function in PrioritizeCommand.java).
+        // We have also checked that if present, the threshold is in [0,1]
+        // the YAML parser performs analogous checks.
         this.minDifferentials = builder.minDifferentials;
+        this.lrThreshold = builder.lrThreshold;
+        // By default, output everything down to a threshold of 5%.
+        // this will happen if the user does not pass either the -m or the -t option
+        if (minDifferentials == null && lrThreshold == null) {
+            lrThreshold = DEFAULT_LR_THRESHOLD;
+        }
+
         this.phenotypeAnnotationPath=builder.phenotypeAnnotationPath;
         this.transcriptdatabase=builder.transcriptdatabase;
         this.vcfPath=builder.vcfPath;
@@ -195,7 +210,7 @@ public class LiricalFactory {
         } else {
             this.desiredDatabasePrefixes=ImmutableList.of("OMIM","DECIPHER");
         }
-        this.lrThreshold = builder.lrThreshold;
+
     }
 
     public String getOutfilePrefix() {

--- a/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
+++ b/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
@@ -46,10 +46,25 @@ public class YamlParser {
             yconfig=null;
             throw new LiricalRuntimeException("Could not find YAML file: "+ e.getMessage());
         }
+        checkThresholds();
     }
 
-
-
+    /** At most one option can be used. If the threshold option is used, it must be between 0 and 1. */
+    private void checkThresholds() {
+        Optional<Integer>  midopt = mindiff();
+        Optional<Double> thopt = threshold();
+        if (midopt.isPresent() && thopt.isPresent()) {
+            System.err.println("[ERROR] Only one of the options -t/--threshold and -m/--mindiff can be used at once.");
+            throw new LiricalRuntimeException("Only one of the options -t/--threshold and -m/--mindiff can be used at once.");
+        }
+        if (thopt.isPresent()) {
+            double LR_THRESHOLD = thopt.get();
+            if (LR_THRESHOLD < 0.0 || LR_THRESHOLD > 1.0) {
+                System.err.println("[ERROR] Post-test probability (-t/--threshold) must be between 0.0 and 1.0.");
+                throw new LiricalRuntimeException("Post-test probability (-t/--threshold) must be between 0.0 and 1.0.");
+            }
+        }
+    }
 
 
     String getMvStorePath()  {


### PR DESCRIPTION
Added some non-elegant but straightforward code to check this. There is no way to enforce mutual exclusivity with JCommander apparently, and it would require a rewrite of LiricalFactory to do this in a really elegant way. We might consider using Spring to de-spaghettify the construction of objects in LIRICAL, and so I hope we can leave this for now.