### PR TITLE
Prevent outfilePrefix from being set to null

### DIFF
--- a/src/main/java/org/monarchinitiative/lirical/configuration/LiricalFactory.java
+++ b/src/main/java/org/monarchinitiative/lirical/configuration/LiricalFactory.java
@@ -666,10 +666,11 @@ public class LiricalFactory {
                 default:
                     this.transcriptdatabase = TranscriptDatabase.UCSC;
             }
-            this.outfilePrefix = yp.getPrefix();
+            if (yp.getPrefix() != null) {
+                this.outfilePrefix = yp.getPrefix();
+            }
             Optional<Double> threshold = yp.threshold();
             threshold.ifPresent(d -> this.lrThreshold = d);
-            this.outfilePrefix = yp.getPrefix();
             if (yp.mindiff().isPresent()) {
                 this.minDifferentials = yp.mindiff().get();
             }


### PR DESCRIPTION
Prevent outfilePrefix from being set to null in yaml mode when prefix is not specified in YAML file