### PR TITLE
Add missing dependency `protobuf-java-util`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.8.0</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.tukaani/xz
           XZ data compression in pure Java. We just use this (indirectly) in some test cases.

--- a/src/main/java/org/monarchinitiative/lirical/io/PhenopacketImporter.java
+++ b/src/main/java/org/monarchinitiative/lirical/io/PhenopacketImporter.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.lirical.io;
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 
 import org.json.simple.JSONObject;


### PR DESCRIPTION
This is a curious thing. The build fails on my Mac without the dependency that is added in this PR. I am not sure, however, how come it does not fail on your side..