### PR TITLE
Writing of TSV and HTML in same run

### DIFF
--- a/src/main/java/org/monarchinitiative/lirical/cmd/AbstractPrioritizeCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/AbstractPrioritizeCommand.java
@@ -29,8 +29,11 @@ public abstract class AbstractPrioritizeCommand {
     /** The threshold for showing a differential diagnosis in the main section (posterior probability of 5%).*/
     @CommandLine.Option(names= {"-t","--threshold"}, description = "minimum post-test prob. to show diagnosis in HTML output")
     protected Double LR_THRESHOLD = null;
-    /** If true, the program will not output an HTML file but will output a Tab Separated Values file instead.*/
-    @CommandLine.Option(names="--tsv",description = "Use TSV instead of HTML output (default: ${DEFAULT-VALUE})")
+    /** If true, the program will output an HTML file.*/
+    @CommandLine.Option(names="--html", arity = "0..1", description = "Provide HTML output (default: ${DEFAULT-VALUE})")
+    protected boolean outputHTML=true;
+    /** If true, the program will output a Tab Separated Values file.*/
+    @CommandLine.Option(names="--tsv", arity = "0..1", description = "Provide TSV output (default: ${DEFAULT-VALUE})")
     protected boolean outputTSV=false;
     /** Prefix of the output file. For instance, if the user enters {@code -x sample1} and an HTML file is output,
      * the name of the HTML file will be {@code sample1.html}. If a TSV file is output, the name of the file will

--- a/src/main/java/org/monarchinitiative/lirical/cmd/PhenopacketCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/PhenopacketCommand.java
@@ -142,10 +142,13 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand implements Cal
                 .symbolsWithOutIds(symbolsWithoutGeneIds)
                 .mindiff(factory.getMinDifferentials())
                 .prefix(this.outfilePrefix);
-        LiricalTemplate template = outputTSV ?
-                builder.buildGenoPhenoTsvTemplate() :
-                builder.buildGenoPhenoHtmlTemplate();
-        template.outputFile();
+        
+        if (outputTSV) {
+            builder.buildGenoPhenoTsvTemplate().outputFile();
+        }
+        if (outputHTML) {
+            builder.buildGenoPhenoHtmlTemplate().outputFile();
+        }
     }
 
     /**

--- a/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenopacketWithVcfCommand.java
+++ b/src/main/java/org/monarchinitiative/lirical/cmd/SimulatePhenopacketWithVcfCommand.java
@@ -55,12 +55,14 @@ public class SimulatePhenopacketWithVcfCommand extends PhenopacketCommand implem
     private boolean phenotypeOnly=false;
     @CommandLine.Option(names={"--output-vcf"}, description = "output a VCF file or files with results of the simulation")
     private boolean outputVCF = false;
-    @CommandLine.Option(names={"--output-tsv"}, description = "output a TSV file or files with results of the simulation")
-    private boolean outputTSV = false;
+    /** If true, the program will output an HTML file.*/
+    @CommandLine.Option(names="--output-html", arity = "0..1", description = "Provide HTML output (default: ${DEFAULT-VALUE})")
+    protected boolean outputHTML=true;
+    /** If true, the program will output a Tab Separated Values file.*/
+    @CommandLine.Option(names="--output-tsv", arity = "0..1", description = "output a TSV file or files with results of the simulation (default: ${DEFAULT-VALUE})")
+    protected boolean outputTSV=false;
     @CommandLine.Option(names={"--random"},description = "randomize the HPO terms from the phenopacket")
     private boolean randomize = false;
-    /** If true, output HTML or TSV */
-    private boolean outputFiles = false;
 
     private List<LiricalRanking> rankingsList;
     /** Each entry in this list represents one simulated case with various data about the simulation. */
@@ -97,7 +99,8 @@ public class SimulatePhenopacketWithVcfCommand extends PhenopacketCommand implem
         geneRank2CountMap.merge(geneRank,1, Integer::sum); // increment count
         if (outputTSV) {
             simulator.outputTsv(outfilePrefix, factory.getLrThreshold(), factory.getMinDifferentials(), outdir);
-        } else {
+        }
+        if (outputHTML) {
             simulator.outputHtml(outfilePrefix, factory.getLrThreshold(), factory.getMinDifferentials(), outdir);
         }
     }

--- a/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
+++ b/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
@@ -329,7 +329,7 @@ public class YamlParser {
             String k = yconfig.getAnalysis().get("html");
             return k.equalsIgnoreCase("true");
         }
-        return false; // no HTML entry in YAML file
+        return true; // no HTML entry in YAML file
     }
 
 }

--- a/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
+++ b/src/main/java/org/monarchinitiative/lirical/io/YamlParser.java
@@ -324,4 +324,12 @@ public class YamlParser {
         return false; // no TSV entry in YAML file
     }
 
+    public boolean doHtml() {
+        if (yconfig.hasAnalysis() && yconfig.getAnalysis().containsKey("html")) {
+            String k = yconfig.getAnalysis().get("html");
+            return k.equalsIgnoreCase("true");
+        }
+        return false; // no HTML entry in YAML file
+    }
+
 }

--- a/src/test/java/org/monarchinitiative/lirical/io/YamlParserTest.java
+++ b/src/test/java/org/monarchinitiative/lirical/io/YamlParserTest.java
@@ -244,5 +244,19 @@ class YamlParserTest {
         assertTrue(yparser.doTsv());
     }
 
+    @Test
+    void testHtml1() {
+        //example 1 has html with false entry,
+        YamlParser yparser = new YamlParser(example1path);
+        assertFalse(yparser.doHtml());
+    }
+
+    @Test
+    void testHtml2() {
+        //example 2 has  html: true,
+        YamlParser yparser = new YamlParser(example2path);
+        assertTrue(yparser.doHtml());
+    }
+
 
 }

--- a/src/test/java/org/monarchinitiative/lirical/io/YamlParserTest.java
+++ b/src/test/java/org/monarchinitiative/lirical/io/YamlParserTest.java
@@ -248,14 +248,14 @@ class YamlParserTest {
     void testHtml1() {
         //example 1 has html with false entry,
         YamlParser yparser = new YamlParser(example1path);
-        assertFalse(yparser.doHtml());
+        assertTrue(yparser.doHtml());
     }
 
     @Test
     void testHtml2() {
         //example 2 has  html: true,
         YamlParser yparser = new YamlParser(example2path);
-        assertTrue(yparser.doHtml());
+        assertFalse(yparser.doHtml());
     }
 
 

--- a/src/test/resources/yaml/example2.yml
+++ b/src/test/resources/yaml/example2.yml
@@ -14,7 +14,7 @@ analysis:
   strict: true
   threshold: 0.05
   tsv: true
-  html: true
+  html: false
 hpoIds: [ 'HP:0001363', 'HP:0011304', 'HP:0010055']
 negatedHpoIds: ['HP:0001328']
 prefix: example2

--- a/src/test/resources/yaml/example2.yml
+++ b/src/test/resources/yaml/example2.yml
@@ -14,6 +14,7 @@ analysis:
   strict: true
   threshold: 0.05
   tsv: true
+  html: true
 hpoIds: [ 'HP:0001363', 'HP:0011304', 'HP:0010055']
 negatedHpoIds: ['HP:0001328']
 prefix: example2


### PR DESCRIPTION
Add command line options to write TSV and HTML files in same analysis for YAML and PhenoPacket sub-command.

Write both files command examples for phenopacket 
```
LIRICAL.jar phenopacket ... --html true --tsv true
LIRICAL.jar phenopacket ... --tsv true
```

Write both files configuration example for YAML
```
analysis:
  ...
  html: true
  tsv: true
```

