### PR TITLE
Allow running without Exomiser

### DIFF
--- a/lirical-configuration/src/main/java/org/monarchinitiative/lirical/configuration/LiricalBuilder.java
+++ b/lirical-configuration/src/main/java/org/monarchinitiative/lirical/configuration/LiricalBuilder.java
@@ -190,8 +190,15 @@ public class LiricalBuilder {
         }
 
         if (variantMetadataService == null) {
-            LOGGER.debug("Variant metadata service is unset. Trying to create the service from frequency service and pathogenicity service.");
-            variantMetadataService = ExomiserMvStoreMetadataService.of(exomiserVariantDatabase, new VariantMetadataService.Options(defaultVariantAlleleFrequency));
+            LOGGER.debug("Variant metadata service is unset.");
+            if (exomiserVariantDatabase == null) {
+                LOGGER.debug("Path to Exomiser database is unset. Variants will not be annotated.");
+                // TODO - is this what we actually want to do?
+                variantMetadataService = NoOpVariantMetadataService.instance();
+            } else {
+                LOGGER.debug("Using Exomiser variant database at {}", exomiserVariantDatabase.toAbsolutePath());
+                variantMetadataService = ExomiserMvStoreMetadataService.of(exomiserVariantDatabase, new VariantMetadataService.Options(defaultVariantAlleleFrequency));
+            }
         }
 
         // Variant parser factory


### PR DESCRIPTION
`LiricalBuilder` does not fail when path to Exomiser variant database is missing.