### PR TITLE
Add `PretestDiseaseProbability` to `AnalysisOptions`.

### DIFF
--- a/lirical-benchmark/src/main/java/org/monarchinitiative/lirical/benchmark/cmd/BenchmarkCommand.java
+++ b/lirical-benchmark/src/main/java/org/monarchinitiative/lirical/benchmark/cmd/BenchmarkCommand.java
@@ -7,6 +7,8 @@ import org.monarchinitiative.lirical.configuration.GenotypeLrProperties;
 import org.monarchinitiative.lirical.core.Lirical;
 import org.monarchinitiative.lirical.configuration.LiricalBuilder;
 import org.monarchinitiative.lirical.core.analysis.*;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbabilities;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
 import org.monarchinitiative.lirical.core.model.*;
 import org.monarchinitiative.lirical.core.service.FunctionalVariantAnnotator;
 import org.monarchinitiative.lirical.core.service.HpoTermSanitizer;
@@ -96,7 +98,7 @@ public class BenchmarkCommand extends AbstractBenchmarkCommand {
 
         // 2 - prepare the simulation input.
         BenchmarkData benchmarkData = prepareBenchmarkData(lirical);
-        AnalysisOptions analysisOptions = prepareAnalysisOptions();
+        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical);
 
         // 3 - run the analysis.
         LOGGER.info("Starting the analysis: {}", analysisOptions);
@@ -238,8 +240,9 @@ public class BenchmarkCommand extends AbstractBenchmarkCommand {
         };
     }
 
-    protected AnalysisOptions prepareAnalysisOptions() {
-        return new AnalysisOptions(runConfiguration.globalAnalysisMode);
+    private AnalysisOptions prepareAnalysisOptions(Lirical lirical) {
+        PretestDiseaseProbability pretestDiseaseProbability = PretestDiseaseProbabilities.uniform(lirical.phenotypeService().diseases());
+        return AnalysisOptions.of(runConfiguration.globalAnalysisMode, pretestDiseaseProbability);
     }
 
 

--- a/lirical-beta/src/main/java/org/monarchinitiative/lirical/beta/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-beta/src/main/java/org/monarchinitiative/lirical/beta/cmd/AbstractPrioritizeCommand.java
@@ -1,13 +1,11 @@
 package org.monarchinitiative.lirical.beta.cmd;
 
 import org.monarchinitiative.lirical.core.Lirical;
+import org.monarchinitiative.lirical.core.analysis.*;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbabilities;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
 import org.monarchinitiative.lirical.core.output.*;
 import org.monarchinitiative.lirical.core.service.TranscriptDatabase;
-import org.monarchinitiative.lirical.core.analysis.AnalysisData;
-import org.monarchinitiative.lirical.core.analysis.AnalysisOptions;
-import org.monarchinitiative.lirical.core.analysis.AnalysisResults;
-import org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner;
-import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.core.exception.LiricalRuntimeException;
 import org.monarchinitiative.lirical.core.model.*;
 import org.monarchinitiative.lirical.io.LiricalDataException;
@@ -151,7 +149,7 @@ abstract class AbstractPrioritizeCommand implements Callable<Integer> {
         }
 
         // 3 - run the analysis
-        AnalysisOptions analysisOptions = prepareAnalysisOptions();
+        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical);
         LOGGER.info("Starting the analysis");
         LiricalAnalysisRunner analysisRunner = lirical.analysisRunner();
         AnalysisResults results = analysisRunner.run(analysisData, analysisOptions);
@@ -187,8 +185,9 @@ abstract class AbstractPrioritizeCommand implements Callable<Integer> {
 
     protected abstract AnalysisData prepareAnalysisData(Lirical lirical) throws LiricalParseException;
 
-    protected AnalysisOptions prepareAnalysisOptions() {
-        return new AnalysisOptions(runConfiguration.globalAnalysisMode);
+    private AnalysisOptions prepareAnalysisOptions(Lirical lirical) {
+        PretestDiseaseProbability pretestDiseaseProbability = PretestDiseaseProbabilities.uniform(lirical.phenotypeService().diseases());
+        return AnalysisOptions.of(runConfiguration.globalAnalysisMode, pretestDiseaseProbability);
     }
 
     protected abstract AnalysisResultsMetadata.Builder fillDataSection(AnalysisResultsMetadata.Builder builder);

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -2,13 +2,11 @@ package org.monarchinitiative.lirical.cli.cmd;
 
 import org.monarchinitiative.lirical.configuration.*;
 import org.monarchinitiative.lirical.core.Lirical;
+import org.monarchinitiative.lirical.core.analysis.*;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbabilities;
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
 import org.monarchinitiative.lirical.core.output.*;
 import org.monarchinitiative.lirical.core.service.TranscriptDatabase;
-import org.monarchinitiative.lirical.core.analysis.AnalysisData;
-import org.monarchinitiative.lirical.core.analysis.AnalysisOptions;
-import org.monarchinitiative.lirical.core.analysis.AnalysisResults;
-import org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner;
-import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.core.exception.LiricalRuntimeException;
 import org.monarchinitiative.lirical.core.model.*;
 import org.monarchinitiative.lirical.io.LiricalDataException;
@@ -182,7 +180,7 @@ abstract class AbstractPrioritizeCommand implements Callable<Integer> {
         }
 
         // 3 - run the analysis
-        AnalysisOptions analysisOptions = prepareAnalysisOptions();
+        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical);
         LOGGER.info("Starting the analysis");
         LiricalAnalysisRunner analysisRunner = lirical.analysisRunner();
         AnalysisResults results = analysisRunner.run(analysisData, analysisOptions);
@@ -237,8 +235,9 @@ abstract class AbstractPrioritizeCommand implements Callable<Integer> {
 
     protected abstract AnalysisData prepareAnalysisData(Lirical lirical) throws LiricalParseException;
 
-    protected AnalysisOptions prepareAnalysisOptions() {
-        return new AnalysisOptions(runConfiguration.globalAnalysisMode);
+    private AnalysisOptions prepareAnalysisOptions(Lirical lirical) {
+        PretestDiseaseProbability pretestDiseaseProbability = PretestDiseaseProbabilities.uniform(lirical.phenotypeService().diseases());
+        return AnalysisOptions.of(runConfiguration.globalAnalysisMode, pretestDiseaseProbability);
     }
 
     protected OutputOptions createOutputOptions() {

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
@@ -1,4 +1,27 @@
 package org.monarchinitiative.lirical.core.analysis;
 
-public record AnalysisOptions(boolean useGlobal) {
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
+
+import java.util.Objects;
+
+/**
+ * A container for analysis-specific settings, i.e. settings that need to be changed for analysis of each sample.
+ */
+public interface AnalysisOptions {
+
+    static AnalysisOptions of(boolean useGlobal, PretestDiseaseProbability pretestDiseaseProbability) {
+        Objects.requireNonNull(pretestDiseaseProbability);
+        return new AnalysisOptionsDefault(useGlobal, pretestDiseaseProbability);
+    }
+
+    /**
+     * @return <code>true</code> if the <em>global</em> analysis mode should be used.
+     */
+    boolean useGlobal();
+
+    /**
+     * @return pretest disease probability container.
+     */
+    PretestDiseaseProbability pretestDiseaseProbability();
+
 }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptionsDefault.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptionsDefault.java
@@ -1,0 +1,10 @@
+package org.monarchinitiative.lirical.core.analysis;
+
+import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
+
+record AnalysisOptionsDefault(
+        boolean useGlobal,
+        PretestDiseaseProbability pretestDiseaseProbability
+) implements AnalysisOptions {
+
+}


### PR DESCRIPTION
Add `PretestDiseaseProbability` to `AnalysisOptions` so that analyses can be run with different pretest disease probabilities. The `PretestDiseaseProbability` is deprecated in `LiricalBuilder`, scheduled for removal in `v2.0.0`.