### PR TITLE
Rework logging

### DIFF
--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BaseCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BaseCommand.java
@@ -1,0 +1,74 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+/**
+ * The command that sets up logging and then runs the downstream command.
+ */
+abstract class BaseCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"-v"},
+            description = {"Specify multiple -v options to increase verbosity.",
+            "For example, `-v -v -v` or `-vvv`"})
+    public boolean[] verbosity = {};
+
+    @Override
+    public Integer call() {
+        // (0) Setup verbosity and print banner.
+        setupLoggingAndPrintBanner();
+
+        // (1) Run the command functionality.
+        return execute();
+    }
+
+    protected abstract Integer execute();
+
+    private void setupLoggingAndPrintBanner() {
+        Level level = parseVerbosityLevel();
+
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(level);
+
+        if (!(level.equals(Level.WARN) || level.equals(Level.ERROR)))
+            printBanner();
+    }
+
+    private static String readBanner() {
+        try (InputStream is = new BufferedInputStream(Objects.requireNonNull(LiricalConfigurationCommand.class.getResourceAsStream("/banner.txt")))) {
+            return new String(is.readAllBytes());
+        } catch (IOException e) {
+            // swallow
+            return "";
+        }
+    }
+
+    private Level parseVerbosityLevel() {
+        int verbosity = 0;
+        for (boolean a : this.verbosity) {
+            if (a) verbosity++;
+        }
+
+        return switch (verbosity) {
+            case 0 -> Level.WARN;
+            case 1 -> Level.INFO;
+            case 2 -> Level.DEBUG;
+            case 3 -> Level.TRACE;
+            default -> Level.ALL;
+        };
+    }
+
+    private static void printBanner() {
+        System.err.println(readBanner());
+    }
+
+}

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/DownloadCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/DownloadCommand.java
@@ -11,7 +11,6 @@ import picocli.CommandLine;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.concurrent.Callable;
 
 /**
  * Download a number of files needed for the analysis. We download by default to a subdirectory called
@@ -19,13 +18,13 @@ import java.util.concurrent.Callable;
  * {@code Homo_sapiencs_gene_info.gz}, and {@code mim2gene_medgen}.
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
-
 @CommandLine.Command(name = "download",
         aliases = {"D"},
         sortOptions = false,
         mixinStandardHelpOptions = true,
         description = "Download files for LIRICAL.")
-public class DownloadCommand implements Callable<Integer>{
+public class DownloadCommand extends BaseCommand {
+
     private static final Logger logger = LoggerFactory.getLogger(DownloadCommand.class);
 
     @CommandLine.Option(names={"-d","--data"},
@@ -37,7 +36,7 @@ public class DownloadCommand implements Callable<Integer>{
     public boolean overwrite = false;
 
     @Override
-    public Integer call() {
+    public Integer execute() {
         try {
             logger.info("Downloading data to {}", datadir.toAbsolutePath());
 

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -18,28 +18,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 /**
  * Base class that describes data and configuration sections of the CLI, and contains common functionalities.
  */
-abstract class BaseLiricalCommand implements Callable<Integer> {
+abstract class LiricalConfigurationCommand extends BaseCommand {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseLiricalCommand.class);
-
-    private static String readBanner() {
-        try (InputStream is = new BufferedInputStream(Objects.requireNonNull(BaseLiricalCommand.class.getResourceAsStream("/banner.txt")))) {
-            return new String(is.readAllBytes());
-        } catch (IOException e) {
-            // swallow
-            return "";
-        }
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(LiricalConfigurationCommand.class);
 
     // ---------------------------------------------- RESOURCES --------------------------------------------------------
     @CommandLine.ArgGroup(validate = false, heading = "Resource paths:%n")
@@ -121,10 +110,6 @@ abstract class BaseLiricalCommand implements Callable<Integer> {
                         "NOTE: the option has been DEPRECATED"
         })
         public float defaultAlleleFrequency = Float.NaN;
-    }
-
-    protected static void printBanner() {
-        System.out.println(readBanner());
     }
 
     protected List<String> checkInput() {
@@ -338,7 +323,7 @@ abstract class BaseLiricalCommand implements Callable<Integer> {
     }
 
     private static Path codeHomeDir() {
-        String codePath = BaseLiricalCommand.class.getProtectionDomain().getCodeSource().getLocation().getFile();
+        String codePath = LiricalConfigurationCommand.class.getProtectionDomain().getCodeSource().getLocation().getFile();
         LOGGER.debug("Found code path at {}", codePath);
         return Path.of(codePath).toAbsolutePath().getParent();
     }

--- a/lirical-cli/src/main/resources/logback.xml
+++ b/lirical-cli/src/main/resources/logback.xml
@@ -6,30 +6,14 @@
 
     <property name="pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
-    <!-- We write INFO and above events to console. -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-        <encoder>
-            <pattern>${pattern}</pattern>
-        </encoder>
-    </appender>
-
-    <!-- We write DEBUG and above events into the lirical.log file. -->
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
-        </filter>
-        <file>lirical.log</file>
-        <append>false</append>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
         <encoder>
             <pattern>${pattern}</pattern>
         </encoder>
     </appender>
 
     <root>
-        <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
+        <appender-ref ref="STDERR" />
     </root>
 </configuration>

--- a/lirical-cli/src/main/resources/logback.xml
+++ b/lirical-cli/src/main/resources/logback.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- We're not interested in seeing all events produced by the following libraries: -->
-    <logger name="de.charite.compbio.jannovar" level="WARN" />
-    <logger name="org.monarchinitiative.phenol" level="DEBUG" />
-
     <property name="pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
All logging is done on the console. By default, LIRICAL only reports warnings and errors. The verbosity can be increased using `-v`, `-vv` or `-vvv` CLI options to show *INFO*, *INFO + DEBUG*, or *INFO + DEBUG + TRACE* messages.