### PR TITLE
Shrink poisson API, improve javadocs, use selected disease databases to calculate pretest probability

### DIFF
--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -94,7 +94,7 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                 description = {
                 "Default frequency of called-pathogenic variants in the general population (gnomAD).",
                         "In the vast majority of cases, we can derive this information from gnomAD.",
-                        "This constant is used if for whatever reason, data was not available.",
+                        "This constant is used if for whatever reason, data was not available for a gene.",
                         "(default: ${DEFAULT-VALUE})."})
         public double defaultVariantBackgroundFrequency = 0.1;
 

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -241,7 +241,7 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
         builder.useGlobal(runConfiguration.globalAnalysisMode);
 
         LOGGER.debug("Using uniform pretest disease probabilities.");
-        PretestDiseaseProbability pretestDiseaseProbability = PretestDiseaseProbabilities.uniform(lirical.phenotypeService().diseases());
+        PretestDiseaseProbability pretestDiseaseProbability = PretestDiseaseProbabilities.uniform(lirical.phenotypeService().diseases(), diseaseDatabases);
         builder.pretestProbability(pretestDiseaseProbability);
 
         LOGGER.debug("Disregarding diseases with no deleterious variants? {}", runConfiguration.disregardDiseaseWithNoDeleteriousVariants);

--- a/lirical-configuration/src/main/java/org/monarchinitiative/lirical/configuration/impl/BundledBackgroundVariantFrequencyServiceFactory.java
+++ b/lirical-configuration/src/main/java/org/monarchinitiative/lirical/configuration/impl/BundledBackgroundVariantFrequencyServiceFactory.java
@@ -30,7 +30,8 @@ public class BundledBackgroundVariantFrequencyServiceFactory implements Backgrou
     }
 
     @Override
-    public Optional<BackgroundVariantFrequencyService> forGenomeBuild(GenomeBuild genomeBuild, double defaultVariantBackgroundFrequency) {
+    public Optional<BackgroundVariantFrequencyService> forGenomeBuild(GenomeBuild genomeBuild,
+                                                                      double defaultVariantBackgroundFrequency) {
         try (BufferedReader br = openBundledBackgroundFrequencyFile(genomeBuild)) {
             Map<TermId, Double> frequencyMap = BackgroundVariantFrequencyParser.parse(br);
             return Optional.of(BackgroundVariantFrequencyService.of(frequencyMap, defaultVariantBackgroundFrequency));

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/PretestDiseaseProbabilities.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/PretestDiseaseProbabilities.java
@@ -2,10 +2,14 @@ package org.monarchinitiative.lirical.core.analysis.probability;
 
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseases;
+import org.monarchinitiative.phenol.annotations.io.hpo.DiseaseDatabase;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A collection of {@link PretestDiseaseProbability} instances.
@@ -15,12 +19,43 @@ public class PretestDiseaseProbabilities {
     private PretestDiseaseProbabilities() {
     }
 
+    /**
+     * @deprecated use {@link #uniform(HpoDiseases, Collection)} instead
+     */
+    // REMOVE(v2.0.0)
+    @Deprecated(forRemoval = true)
     public static PretestDiseaseProbability uniform(HpoDiseases diseases) {
         Map<TermId, Double> pretestProbabilities = new HashMap<>(diseases.size());
 
         double prob = 1.0 / diseases.size();
         for (HpoDisease disease : diseases) {
             pretestProbabilities.put(disease.id(), prob);
+        }
+
+        return PretestDiseaseProbability.of(pretestProbabilities);
+    }
+
+    /**
+     * Prepare uniform pretest disease probabilities for diseases from disease databases.
+     * <p>
+     * Note, we only use the diseases from the provided {@code diseaseDatabases}.
+     *
+     * @return uniform pretest disease probabilities.
+     */
+    public static PretestDiseaseProbability uniform(HpoDiseases diseases,
+                                                    Collection<DiseaseDatabase> diseaseDatabases) {
+        Set<String> diseasePrefixes = diseaseDatabases.stream()
+                .map(DiseaseDatabase::prefix)
+                .collect(Collectors.toSet());
+        long diseaseCount = diseases.stream()
+                .filter(d -> diseasePrefixes.contains(d.id().getPrefix()))
+                .count();
+
+        Map<TermId, Double> pretestProbabilities = new HashMap<>(Math.toIntExact(diseaseCount));
+        double proba = 1.0 / diseaseCount;
+        for (HpoDisease disease : diseases) {
+            if (diseasePrefixes.contains(disease.id().getPrefix()))
+                pretestProbabilities.put(disease.id(), proba);
         }
 
         return PretestDiseaseProbability.of(pretestProbabilities);

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/PretestDiseaseProbabilities.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/PretestDiseaseProbabilities.java
@@ -2,14 +2,11 @@ package org.monarchinitiative.lirical.core.analysis.probability;
 
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseases;
-import org.monarchinitiative.phenol.annotations.io.hpo.DiseaseDatabase;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A collection of {@link PretestDiseaseProbability} instances.
@@ -20,7 +17,7 @@ public class PretestDiseaseProbabilities {
     }
 
     /**
-     * @deprecated use {@link #uniform(HpoDiseases, Collection)} instead
+     * @deprecated use {@link #uniform(Collection)} instead
      */
     // REMOVE(v2.0.0)
     @Deprecated(forRemoval = true)
@@ -36,26 +33,15 @@ public class PretestDiseaseProbabilities {
     }
 
     /**
-     * Prepare uniform pretest disease probabilities for diseases from disease databases.
-     * <p>
-     * Note, we only use the diseases from the provided {@code diseaseDatabases}.
+     * Prepare uniform pretest disease probabilities for given disease identifiers.
      *
      * @return uniform pretest disease probabilities.
      */
-    public static PretestDiseaseProbability uniform(HpoDiseases diseases,
-                                                    Collection<DiseaseDatabase> diseaseDatabases) {
-        Set<String> diseasePrefixes = diseaseDatabases.stream()
-                .map(DiseaseDatabase::prefix)
-                .collect(Collectors.toSet());
-        long diseaseCount = diseases.stream()
-                .filter(d -> diseasePrefixes.contains(d.id().getPrefix()))
-                .count();
-
-        Map<TermId, Double> pretestProbabilities = new HashMap<>(Math.toIntExact(diseaseCount));
-        double proba = 1.0 / diseaseCount;
-        for (HpoDisease disease : diseases) {
-            if (diseasePrefixes.contains(disease.id().getPrefix()))
-                pretestProbabilities.put(disease.id(), proba);
+    public static PretestDiseaseProbability uniform(Collection<TermId> diseaseIds) {
+        Map<TermId, Double> pretestProbabilities = new HashMap<>(diseaseIds.size());
+        double proba = 1.0 / diseaseIds.size();
+        for (TermId diseaseId : diseaseIds) {
+            pretestProbabilities.put(diseaseId, proba);
         }
 
         return PretestDiseaseProbability.of(pretestProbabilities);

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
@@ -21,9 +21,9 @@ import org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritan
  */
 public class GenotypeLikelihoodRatio {
     private static final Logger logger = LoggerFactory.getLogger(GenotypeLikelihoodRatio.class);
-    /** A heuristic to downweight an  disease by a factor of 1/10 if the number of predicted pathogenic alleles in
+    /** A heuristic to down-weight a disease by a factor of 1/10 if the number of predicted pathogenic alleles in
      * the VCF file is above lambda_d. */
-    final double HEURISTIC_PATH_ALLELE_COUNT_ABOVE_LAMBDA_D = 0.10;
+    private static final double HEURISTIC_PATH_ALLELE_COUNT_ABOVE_LAMBDA_D = 0.10;
     private static final double DEFAULT_GLR = 0.05;
     /** A small-ish number to avoid dividing by zero. */
     private static final double EPSILON = 1e-5;
@@ -140,7 +140,7 @@ public class GenotypeLikelihoodRatio {
         // Therefore, we apply the main algorithm for calculating the LR genotype score.
 
         double lambda_background = backgroundVariantFrequencyService.frequencyForGene(g2g.geneId().id())
-                .orElse(backgroundVariantFrequencyService.defaultVariantFrequency());
+                .orElse(backgroundVariantFrequencyService.defaultVariantBackgroundFrequency());
         if (inheritancemodes == null || inheritancemodes.isEmpty()) {
             // This is probably because the HPO annotation file is incomplete
             logger.warn("No inheritance mode annotation found for geneId {}, reverting to default", g2g.geneId().id().getValue());
@@ -207,9 +207,19 @@ public class GenotypeLikelihoodRatio {
         // we do not crash if something unexpected occurs. (Should actually never be used)
         double returnvalue = max == null ? DEFAULT_GLR : max;
         if (heuristicPathCountAboveLambda) {
-            return GenotypeLrWithExplanation.explainPathCountAboveLambdaB(g2g.geneId(), returnvalue, maxInheritanceMode, lambda_background, observedWeightedPathogenicVariantCount);
+            return GenotypeLrWithExplanation.explainPathCountAboveLambdaB(g2g.geneId(),
+                    returnvalue,
+                    maxInheritanceMode,
+                    lambda_background,
+                    observedWeightedPathogenicVariantCount);
         } else {
-            return GenotypeLrWithExplanation.explanation(g2g.geneId(), returnvalue, maxInheritanceMode,lambda_background, B, D, observedWeightedPathogenicVariantCount);
+            return GenotypeLrWithExplanation.explanation(g2g.geneId(),
+                    returnvalue,
+                    maxInheritanceMode,
+                    lambda_background,
+                    B,
+                    D,
+                    observedWeightedPathogenicVariantCount);
         }
     }
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/Gamma.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/Gamma.java
@@ -1,6 +1,6 @@
 package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
 
-public class Gamma {
+class Gamma {
     /**
      * <a href="http://en.wikipedia.org/wiki/Euler-Mascheroni_constant">Euler-Mascheroni constant</a>
      * @since 2.0
@@ -180,7 +180,7 @@ public class Gamma {
      * @return the value of {@code log(Gamma(x))}, {@code Double.NaN} if
      * {@code x <= 0.0}.
      */
-    static double logGamma(double x) throws NumberIsTooLargeException,NumberIsTooSmallException {
+    static double logGamma(double x) throws NumberIsTooLargeException, NumberIsTooSmallException {
         double ret;
 
         if (Double.isNaN(x) || (x <= 0.0)) {
@@ -340,8 +340,7 @@ public class Gamma {
      * @throws NumberIsTooLargeException if {@code x > 1.5}.
      * @since 3.1
      */
-    private static double logGamma1p(final double x)
-            throws NumberIsTooSmallException, NumberIsTooLargeException {
+    private static double logGamma1p(final double x) throws NumberIsTooSmallException, NumberIsTooLargeException {
 
         if (x < -0.5) {
             throw new NumberIsTooSmallException(x, -0.5);

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/MaxCountExceededException.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/MaxCountExceededException.java
@@ -1,8 +1,0 @@
-package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
-
-public class MaxCountExceededException extends Exception {
-
-    public MaxCountExceededException(int mc) {
-        super(String.valueOf(mc));
-    }
-}

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/NumberIsTooLargeException.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/NumberIsTooLargeException.java
@@ -1,6 +1,8 @@
 package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
 
-public class NumberIsTooLargeException extends Exception {
+import org.monarchinitiative.lirical.core.exception.LiricalException;
+
+class NumberIsTooLargeException extends LiricalException {
     public NumberIsTooLargeException(double mc, double threshold) {
         super(String.format("%f exceeded %f",mc,threshold));
     }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/NumberIsTooSmallException.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/NumberIsTooSmallException.java
@@ -1,6 +1,8 @@
 package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
 
-public class NumberIsTooSmallException extends Exception {
+import org.monarchinitiative.lirical.core.exception.LiricalException;
+
+class NumberIsTooSmallException extends LiricalException {
     public NumberIsTooSmallException(double mc, double threshold) {
         super(String.format("%f exceeded %f",mc,threshold));
     }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/PoissonDistribution.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/PoissonDistribution.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
 
-import static org.monarchinitiative.lirical.core.likelihoodratio.poisson.SaddlePointExpansion.TWO_PI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class and the other classes in this package were adapted and mainly copied from the
@@ -9,6 +10,8 @@ import static org.monarchinitiative.lirical.core.likelihoodratio.poisson.SaddleP
  * into LIRICAL.
  */
 public class PoissonDistribution {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoissonDistribution.class);
 
     private final double mean;
 
@@ -31,7 +34,7 @@ public class PoissonDistribution {
     }
 
 
-    public double logProbability(double x) {
+    private double logProbability(double x) {
         if (x < 0 || x == Integer.MAX_VALUE) {
             return Double.NEGATIVE_INFINITY;
         } else if (x == 0) {
@@ -40,9 +43,10 @@ public class PoissonDistribution {
             try {
                 return -SaddlePointExpansion.getStirlingError(x) -
                                 SaddlePointExpansion.getDeviancePart(x, mean) -
-                                0.5 * Math.log(TWO_PI) - 0.5 * Math.log(x);
+                                0.5 * Math.log(SaddlePointExpansion.TWO_PI) - 0.5 * Math.log(x);
             } catch (NumberIsTooSmallException | NumberIsTooLargeException e) {
-                e.printStackTrace();
+                LOGGER.warn("{}", e.getMessage());
+                LOGGER.debug("{}", e.getMessage(), e);
                 return Double.NEGATIVE_INFINITY;
             }
         }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/SaddlePointExpansion.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/poisson/SaddlePointExpansion.java
@@ -66,7 +66,7 @@ package org.monarchinitiative.lirical.core.likelihoodratio.poisson;
          * @param z the value.
          * @return the Striling's series error.
          */
-        static double getStirlingError(double z) throws NumberIsTooSmallException,NumberIsTooLargeException{
+        static double getStirlingError(double z) throws NumberIsTooSmallException, NumberIsTooLargeException{
             double ret;
             if (z < 15.0) {
                 double z2 = 2.0 * z;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinvarClnSig.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinvarClnSig.java
@@ -1,5 +1,8 @@
 package org.monarchinitiative.lirical.core.model;
 
+/**
+ * Clinvar clinical significance categories.
+ */
 public enum ClinvarClnSig {
 
     PATHOGENIC,

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadata.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadata.java
@@ -16,10 +16,37 @@ public interface VariantMetadata {
                 clinvarClnSig);
     }
 
+    /**
+     * Get variant frequency as a percentage or an empty optional if the variant has not been observed in any available
+     * variant database.
+     * <p>
+     * For instance, <code>0.5</code> for a variant with frequency <code>1/500</code>.
+     *
+     * @return optional variant frequency as a percentage.
+     */
     Optional<Float> frequency();
 
+    /**
+     * Get estimate of the overall variant pathogenicity.
+     * <p>
+     * The estimate must be in range <code>[0, 1]</code> where <code>0</code> and <code>1</code> represent
+     * the <em>least</em> and the <em>most</em> deleterious variants.
+     * <p>
+     * The estimate can be an aggregate of multiple scoring tools or a product of a single tool.
+     *
+     * @return the overall variant pathogenicity estimate.
+     */
     float pathogenicity();
 
+    /**
+     * Get aggregated variant pathogenicity score.
+     * <p>
+     * The Clinvar pathogenic or likely pathogenic variants are assigned a score of <code>1</code>.
+     * The other variants are assigned a product of the {@link #frequencyScore()} and {@link #pathogenicity()}.
+     * An empty optional is returned if the {@link #frequencyScore()} is missing.
+     *
+     * @return optional pathogenicity score.
+     */
     default Optional<Float> pathogenicityScore() {
         // Heuristic -- Count ClinVar pathogenic or likely pathogenic as 1.0 (maximum pathogenicity score)
         // regardless of the Exomiser pathogenicity score
@@ -28,6 +55,9 @@ public interface VariantMetadata {
                 : frequencyScore().map(fs -> fs * pathogenicity());
     }
 
+    /**
+     * @return Clinvar clinical significance category.
+     */
     ClinvarClnSig clinvarClnSig();
 
     /**

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/BackgroundVariantFrequencyService.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/BackgroundVariantFrequencyService.java
@@ -7,11 +7,20 @@ import java.util.Optional;
 
 public interface BackgroundVariantFrequencyService {
 
-    static BackgroundVariantFrequencyService of(Map<TermId, Double> frequencyMap, double defaultVariantFrequency) {
-        return new BackgroundVariantFrequencyServiceImpl(frequencyMap, defaultVariantFrequency);
+    static BackgroundVariantFrequencyService of(Map<TermId, Double> frequencyMap, double defaultVariantBackgroundFrequency) {
+        return new BackgroundVariantFrequencyServiceImpl(frequencyMap, defaultVariantBackgroundFrequency);
     }
 
-    double defaultVariantFrequency();
+    /**
+     * @deprecated use {@link #defaultVariantBackgroundFrequency()} instead
+     */
+    // REMOVE(v2.0.0)
+    @Deprecated(forRemoval = true)
+    default double defaultVariantFrequency() {
+        return defaultVariantBackgroundFrequency();
+    }
+
+    double defaultVariantBackgroundFrequency();
 
     Optional<Double> frequencyForGene(TermId geneId);
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/BackgroundVariantFrequencyServiceImpl.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/BackgroundVariantFrequencyServiceImpl.java
@@ -9,17 +9,17 @@ import java.util.Optional;
 class BackgroundVariantFrequencyServiceImpl implements BackgroundVariantFrequencyService {
 
     private final Map<TermId, Double> frequencyMap;
-    private final double defaultVariantFrequency;
+    private final double defaultVariantBackgroundFrequency;
 
     BackgroundVariantFrequencyServiceImpl(Map<TermId, Double> frequencyMap,
-                                          double defaultVariantFrequency) {
+                                          double defaultVariantBackgroundFrequency) {
         this.frequencyMap = Objects.requireNonNull(frequencyMap);
-        this.defaultVariantFrequency = defaultVariantFrequency;
+        this.defaultVariantBackgroundFrequency = defaultVariantBackgroundFrequency;
     }
 
     @Override
-    public double defaultVariantFrequency() {
-        return defaultVariantFrequency;
+    public double defaultVariantBackgroundFrequency() {
+        return defaultVariantBackgroundFrequency;
     }
 
     @Override

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/VariantMetadataService.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/VariantMetadataService.java
@@ -10,8 +10,10 @@ public interface VariantMetadataService {
 
     /**
      * We will assume a frequency of 1:100,000 if no frequency data is available.
+     * <p>
+     * Note that the frequency is stored as a percentage.
      */
-    float DEFAULT_FREQUENCY = 1e-5f;
+    float DEFAULT_FREQUENCY = 1e-3f;
 
     // REMOVE(v2.0.0)
     @Deprecated(forRemoval = true, since = "2.0.0-RC2")

--- a/lirical-exomiser-db-adapter/src/main/java/org/monarchinitiative/lirical/exomiser_db_adapter/ExomiserMvStoreMetadataService.java
+++ b/lirical-exomiser-db-adapter/src/main/java/org/monarchinitiative/lirical/exomiser_db_adapter/ExomiserMvStoreMetadataService.java
@@ -22,6 +22,7 @@ import java.util.List;
 /**
  * @deprecated the class will be removed from the public API in v2.0.0. Use {@link ExomiserMvStoreMetadataServiceFactory} instead.
  */
+// REMOVE(v2.0.0) - make package private
 @Deprecated
 public class ExomiserMvStoreMetadataService implements VariantMetadataService {
 


### PR DESCRIPTION
- shrink API of the `core.likelihoodratio.poisson` package to the necessary minimum
- improve Javadoc, especially the important bits regarding variant frequencies
- use selected disease databases to calculate pretest disease probability