### PR TITLE
Setup documentation on github.io

### DIFF
--- a/.github/workflows/pages-latest.yml
+++ b/.github/workflows/pages-latest.yml
@@ -1,0 +1,72 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy the latest documentation to GitHub pages
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Runs on pushes targeting the main branch
+  push:
+    branches: [ develop ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+        ref: main
+    
+    - name: Set up Python 3.
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install Python dependencies
+      run: |
+        pip install sphinx
+        pip install sphinx-rtd-theme
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    
+    - name: Build phenopacket-tools
+      run: ./mvnw -Prelease -DskipTests package # We test elsewhere
+
+    - name: Generate examples and build documentation
+      run: |
+        ## Init the target folder. 
+        # We will put all site documentation there.
+        DOCS_VERSION=latest
+        mkdir -p gh-pages/${DOCS_VERSION}
+        touch gh-pages/.nojekyll
+        
+        ## Copy Javadoc
+        # Copy aggregated Javadoc into `apidocs` folder. 
+        # The aggregated docs are built by Maven in `package` phase.
+        
+        APIDOCS=$(pwd)/gh-pages/${DOCS_VERSION}/apidocs
+        printf "Copying Javadocs from %s to %s\n" $(pwd)/target/site/apidocs ${APIDOCS} 
+        cp -r target/site/apidocs ${APIDOCS}
+        
+        ## Build the docs
+        # Generate the HTML pages and move the generated content into the target folder.
+        printf "Building the ${DOCS_VERSION} documentation\n"
+        cd docs/ 
+        make html
+        cd ..
+        mv docs/_build/html/* gh-pages/${DOCS_VERSION}/
+
+
+    - name: Deploy documentation.
+      if: ${{ github.event_name == 'push' }}
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+        branch: gh-pages
+        force: true
+        folder: gh-pages

--- a/.github/workflows/pages-stable.yml
+++ b/.github/workflows/pages-stable.yml
@@ -1,0 +1,72 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy the stable documentation to GitHub pages
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Runs on pushes targeting the main branch
+  push:
+    branches: [ main ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+        ref: main
+    
+    - name: Set up Python 3.
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install Python dependencies
+      run: |
+        pip install sphinx
+        pip install sphinx-rtd-theme
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    
+    - name: Build phenopacket-tools
+      run: ./mvnw -Prelease -DskipTests package # We test elsewhere
+
+    - name: Generate examples and build documentation
+      run: |
+        ## Init the target folder. 
+        # We will put all site documentation there.
+        DOCS_VERSION=latest
+        mkdir -p gh-pages/${DOCS_VERSION}
+        touch gh-pages/.nojekyll
+        
+        ## Copy Javadoc
+        # Copy aggregated Javadoc into `apidocs` folder. 
+        # The aggregated docs are built by Maven in `package` phase.
+        DOCS_VERSION=stable
+        APIDOCS=$(pwd)/gh-pages/${DOCS_VERSION}/apidocs
+        printf "Copying Javadocs from %s to %s\n" $(pwd)/target/site/apidocs ${APIDOCS} 
+        cp -r target/site/apidocs ${APIDOCS}
+        
+        ## Build the docs
+        # Generate the HTML pages and move the generated content into the target folder.
+        printf "Building the ${DOCS_VERSION} documentation\n"
+        cd docs/ 
+        make html
+        cd ..
+        mv docs/_build/html/* gh-pages/${DOCS_VERSION}/
+
+
+    - name: Deploy documentation.
+      if: ${{ github.event_name == 'push' }}
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+        branch: gh-pages
+        force: true
+        folder: gh-pages

--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,15 @@
                                 <goal>jar</goal>
                             </goals>
                         </execution>
+                        <execution>
+                            <!-- Aggregate Javadoc for hosting at the project site. -->
+                            <id>aggregate</id>
+                            <goals>
+                                <goal>aggregate</goal>
+                            </goals>
+                            <phase>package</phase>
+                            <inherited>false</inherited>
+                        </execution>
                     </executions>
                 </plugin>
                 <!-- mvn versions:display-plugin-updates -->


### PR DESCRIPTION
- setup hosting of the docs on *github.io*, publish *latest* (`develop`) and *stable* (`master`) versions
- build aggregated Javadoc