### PR TITLE
Fixing `N/A` in HTML templates when run in phenotype-only mode

### DIFF
--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/output/HtmlTemplate.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/output/HtmlTemplate.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -154,7 +153,7 @@ public class HtmlTemplate extends LiricalTemplate {
                 return genotypeLr.explanation();
             }
         } else {
-            return "No known disease gene";
+            return null;
         }
     }
 

--- a/lirical-core/src/main/resources/org/monarchinitiative/lirical/core/output/liricalHTML.ftl
+++ b/lirical-core/src/main/resources/org/monarchinitiative/lirical/core/output/liricalHTML.ftl
@@ -605,10 +605,10 @@
                         <td>${dd.posttestprob}</td>
                     </tr>
                 </table>
-
                 <br/>
                 <div class="genotype">
                     <div class="genotype-head">
+                        <#if dd.entrezGeneId != "n/a">
                         <h3>
                             <span class="hgvs-symbol">
                                 ${dd.geneSymbol}
@@ -619,6 +619,7 @@
                                 </span>
                             </span>
                         </h3>
+                        </#if>
                         <#if dd.hasGenotypeExplanation()>
                             <p class="genotype-explanation">${dd.genotypeExplanation}</p>
                         </#if>


### PR DESCRIPTION
addressing #610