### PR TITLE
Fix code for genotype-aware analysis starting from a YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target/
 *.iml
 *.log
 data/
+results/
 dependency-reduced-pom.xml
 .settings
 .project

--- a/lirical-cli/src/examples/LDS2.yaml
+++ b/lirical-cli/src/examples/LDS2.yaml
@@ -7,5 +7,5 @@ hpoIds: ['HP:0001659', 'HP:0001166', 'HP:0001631', 'HP:0000193', 'HP:0012385', '
 # negatedHpoIds: []
 age: P9Y
 sex: FEMALE
-# Set real path to a VCF file
-vcf: LDS2.vcf.gz
+# Set real path to a VCF file. For instance, path to the example `LDS2.vcf.gz` file located next to this YAML config.
+# vcf: /path/to/LDS2.vcf.gz

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -76,7 +76,7 @@ abstract class AbstractPrioritizeCommand extends LiricalConfigurationCommand {
         if (!errors.isEmpty()) {
             LOGGER.error("Errors:");
             for (String error : errors)
-                LOGGER.error("- {}", error);
+                LOGGER.error("  {}", error);
             return 1;
         }
 

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AnalysisDataParserAwareCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AnalysisDataParserAwareCommand.java
@@ -11,11 +11,15 @@ import org.monarchinitiative.lirical.io.analysis.AnalysisDataParserFactory;
 abstract class AnalysisDataParserAwareCommand extends AbstractPrioritizeCommand {
 
     @Override
-    protected AnalysisData prepareAnalysisData(Lirical lirical, GenomeBuild genomeBuild, TranscriptDatabase transcriptDb) throws LiricalParseException {
+    protected AnalysisData prepareAnalysisData(Lirical lirical,
+                                               GenomeBuild genomeBuild,
+                                               TranscriptDatabase transcriptDb) throws LiricalParseException {
         HpoTermSanitizer sanitizer = new HpoTermSanitizer(lirical.phenotypeService().hpo());
         AnalysisDataParserFactory parserFactory = new AnalysisDataParserFactory(sanitizer, lirical.variantParserFactory(), lirical.phenotypeService().associationData());
-        return prepareAnalysisData(parserFactory);
+        return prepareAnalysisData(parserFactory, genomeBuild, transcriptDb);
     }
 
-    protected abstract AnalysisData prepareAnalysisData(AnalysisDataParserFactory factory) throws LiricalParseException;
+    protected abstract AnalysisData prepareAnalysisData(AnalysisDataParserFactory factory,
+                                                        GenomeBuild genomeBuild,
+                                                        TranscriptDatabase transcriptDb) throws LiricalParseException;
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
@@ -3,6 +3,8 @@ package org.monarchinitiative.lirical.cli.cmd;
 import org.monarchinitiative.lirical.core.analysis.AnalysisData;
 import org.monarchinitiative.lirical.core.analysis.AnalysisDataParser;
 import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
+import org.monarchinitiative.lirical.core.model.GenomeBuild;
+import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
 import org.monarchinitiative.lirical.io.analysis.AnalysisDataFormat;
 import org.monarchinitiative.lirical.io.analysis.AnalysisDataParserFactory;
 import org.slf4j.Logger;
@@ -43,12 +45,14 @@ public class YamlCommand extends AnalysisDataParserAwareCommand {
     }
 
     @Override
-    protected AnalysisData prepareAnalysisData(AnalysisDataParserFactory factory) throws LiricalParseException {
+    protected AnalysisData prepareAnalysisData(AnalysisDataParserFactory factory,
+                                               GenomeBuild genomeBuild,
+                                               TranscriptDatabase transcriptDb) throws LiricalParseException {
         AnalysisDataParser parser = factory.forFormat(AnalysisDataFormat.YAML);
 
         LOGGER.info("Parsing YAML input file at {}", yamlPath);
         try (InputStream is = Files.newInputStream(yamlPath)) {
-            return parser.parse(is);
+            return parser.parse(is, genomeBuild, transcriptDb);
         } catch (IOException e) {
             throw new LiricalParseException(e);
         }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataParser.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataParser.java
@@ -1,9 +1,21 @@
 package org.monarchinitiative.lirical.core.analysis;
 
+import org.monarchinitiative.lirical.core.model.GenomeBuild;
+import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
+
 import java.io.InputStream;
 
 public interface AnalysisDataParser {
 
-    AnalysisData parse(InputStream is) throws LiricalParseException;
+    /**
+     * @deprecated use {@link #parse(InputStream, GenomeBuild, TranscriptDatabase)} instead.
+     */
+    // REMOVE(v2.0.0)
+    @Deprecated(forRemoval = true)
+    default AnalysisData parse(InputStream is) throws LiricalParseException {
+        return parse(is, GenomeBuild.HG38, TranscriptDatabase.REFSEQ);
+    }
+
+    AnalysisData parse(InputStream is, GenomeBuild build, TranscriptDatabase transcriptDatabase) throws LiricalParseException;
 
 }

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketAnalysisDataParser.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketAnalysisDataParser.java
@@ -3,6 +3,8 @@ package org.monarchinitiative.lirical.io.analysis;
 import org.monarchinitiative.lirical.core.analysis.AnalysisData;
 import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
+import org.monarchinitiative.lirical.core.model.GenomeBuild;
+import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
 import org.monarchinitiative.lirical.core.service.HpoTermSanitizer;
 import org.monarchinitiative.lirical.core.io.VariantParserFactory;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoAssociationData;
@@ -24,10 +26,10 @@ class PhenopacketAnalysisDataParser extends SanitizingAnalysisDataParser {
 
 
     @Override
-    public AnalysisData parse(InputStream is) throws LiricalParseException {
+    public AnalysisData parse(InputStream is, GenomeBuild build, TranscriptDatabase database) throws LiricalParseException {
         PhenopacketData data = importer.read(is);
 
-        GenesAndGenotypes genes = parseGeneToGenotype(data.getSampleId(), data.getVcfPath().orElse(null));
+        GenesAndGenotypes genes = parseGeneToGenotype(data.getSampleId(), data.getVcfPath().orElse(null), build, database);
 
         return AnalysisData.of(data.getSampleId(),
                 data.getAge().orElse(null),

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/YamlAnalysisDataParser.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/YamlAnalysisDataParser.java
@@ -2,9 +2,7 @@ package org.monarchinitiative.lirical.io.analysis;
 
 import org.monarchinitiative.lirical.core.analysis.AnalysisData;
 import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
-import org.monarchinitiative.lirical.core.model.Age;
-import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
-import org.monarchinitiative.lirical.core.model.Sex;
+import org.monarchinitiative.lirical.core.model.*;
 import org.monarchinitiative.lirical.core.service.HpoTermSanitizer;
 import org.monarchinitiative.lirical.core.io.VariantParserFactory;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoAssociationData;
@@ -28,7 +26,7 @@ class YamlAnalysisDataParser extends SanitizingAnalysisDataParser {
     }
 
     @Override
-    public AnalysisData parse(InputStream is) throws LiricalParseException {
+    public AnalysisData parse(InputStream is, GenomeBuild build, TranscriptDatabase database) throws LiricalParseException {
         YamlConfig config;
         try {
             config = YamlParser.parse(is);
@@ -51,7 +49,7 @@ class YamlAnalysisDataParser extends SanitizingAnalysisDataParser {
                 .distinct()
                 .toList();
 
-        GenesAndGenotypes genes = parseGeneToGenotype(sampleId, config.vcfPath().orElse(null));
+        GenesAndGenotypes genes = parseGeneToGenotype(sampleId, config.vcfPath().orElse(null), build, database);
 
         return AnalysisData.of(sampleId, age, sex, presentTerms, absentTerms, genes);
     }


### PR DESCRIPTION
Fix bug in the code for genotype-aware analysis starting from a YAML file. The code did not take into account the selected genomic assembly and transcript database.