### PR TITLE
Add `experimental phenopackets` command

### DIFF
--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/Main.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/Main.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.lirical.cli;
 
 import org.monarchinitiative.lirical.cli.cmd.*;
+import org.monarchinitiative.lirical.cli.cmd.experimental.ExperimentalCommand;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -38,6 +39,8 @@ public class Main implements Callable<Integer> {
                 .addSubcommand("prioritize", new PrioritizeCommand())
                 .addSubcommand("phenopacket", new PhenopacketCommand())
                 .addSubcommand("yaml", new YamlCommand())
+                // hidden commands
+                .addSubcommand("experimental", new ExperimentalCommand())
                 .addSubcommand("benchmark", new BenchmarkCommand());
         cline.setToggleBooleanFlags(false);
         System.exit(cline.execute(args));

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -7,6 +7,7 @@ import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.core.analysis.ProgressReporter;
 import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbabilities;
 import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseaseProbability;
+import org.monarchinitiative.lirical.core.exception.LiricalRuntimeException;
 import org.monarchinitiative.lirical.core.io.VariantParser;
 import org.monarchinitiative.lirical.core.io.VariantParserFactory;
 import org.monarchinitiative.lirical.core.model.*;
@@ -22,6 +23,8 @@ import picocli.CommandLine;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,6 +34,7 @@ import java.util.stream.Collectors;
 abstract class LiricalConfigurationCommand extends BaseCommand {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LiricalConfigurationCommand.class);
+    protected static final String UNKNOWN_VERSION_PLACEHOLDER = "UNKNOWN VERSION";
 
     // ---------------------------------------------- RESOURCES --------------------------------------------------------
     @CommandLine.ArgGroup(validate = false, heading = "Resource paths:%n")
@@ -332,6 +336,20 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                 .toList();
 
         return GenesAndGenotypes.of(g2g);
+    }
+
+    protected static Age parseAge(String age) {
+        if (age == null) {
+            LOGGER.debug("The age was not provided");
+            return Age.ageNotKnown();
+        }
+        try {
+            Period period = Period.parse(age);
+            LOGGER.info("Using age {}", period);
+            return Age.parse(period);
+        } catch (DateTimeParseException e) {
+            throw new LiricalRuntimeException("Unable to parse age '" + age + "': " + e.getMessage(), e);
+        }
     }
 
     protected static void reportElapsedTime(long startTime, long stopTime) {

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/OutputCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/OutputCommand.java
@@ -1,0 +1,77 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import org.monarchinitiative.lirical.core.output.LrThreshold;
+import org.monarchinitiative.lirical.core.output.MinDiagnosisCount;
+import org.monarchinitiative.lirical.core.output.OutputFormat;
+import org.monarchinitiative.lirical.core.output.OutputOptions;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+public abstract class OutputCommand extends LiricalConfigurationCommand {
+
+    // ---------------------------------------------- OUTPUTS ----------------------------------------------------------
+    @CommandLine.ArgGroup(validate = false, heading = "Output options:%n")
+    public Output output = new Output();
+
+    public static class Output {
+        @CommandLine.Option(names = {"-o", "--output-directory"},
+                description = "Directory into which to write output (default: ${DEFAULT-VALUE}).")
+        public Path outdir = Path.of("");
+
+        @CommandLine.Option(names = {"-f", "--output-format"},
+                arity = "0..*",
+                description = {
+                        "An output format to use for writing the results, can be provided multiple times.",
+                        "Choose from {${COMPLETION-CANDIDATES}}",
+                        "Default: ${DEFAULT-VALUE}"
+                })
+        public Set<OutputFormat> outputFormats = Set.of(OutputFormat.HTML);
+        /**
+         * Prefix of the output file. For instance, if the user enters {@code -x sample1} and an HTML file is output,
+         * the name of the HTML file will be {@code sample1.html}. If a TSV file is output, the name of the file will
+         * be {@code sample1.tsv}.
+         */
+        @CommandLine.Option(names = {"-x", "--prefix"},
+                description = "Prefix of outfile (default: ${DEFAULT-VALUE}).")
+        public String outfilePrefix = "lirical";
+
+        @CommandLine.Option(names = {"-t", "--threshold"},
+                description = "Minimum post-test probability to show diagnosis in HTML output. The value should range between [0,1].")
+        public Double lrThreshold = null;
+
+        @CommandLine.Option(names = {"-m", "--mindiff"},
+                description = "Minimal number of differential diagnoses to show.")
+        public Integer minDifferentialsToShow = null;
+
+        @CommandLine.Option(names = {"--display-all-variants"},
+                description = "Display all variants in output, not just variants passing pathogenicity threshold (default ${DEFAULT-VALUE})")
+        public boolean displayAllVariants = false;
+    }
+
+    protected List<String> checkInput() {
+        List<String> errors = super.checkInput();
+
+        // thresholds
+        if (output.lrThreshold != null && output.minDifferentialsToShow != null) {
+            String msg = "Only one of the options -t/--threshold and -m/--mindiff can be used at once.";
+            errors.add(msg);
+        }
+        if (output.lrThreshold != null) {
+            if (output.lrThreshold < 0.0 || output.lrThreshold > 1.0) {
+                String msg = "Post-test probability (-t/--threshold) must be between 0.0 and 1.0.";
+                errors.add(msg);
+            }
+        }
+        return errors;
+    }
+
+    protected OutputOptions createOutputOptions(String prefix) {
+        LrThreshold lrThreshold = output.lrThreshold == null ? LrThreshold.notInitialized() : LrThreshold.setToUserDefinedThreshold(output.lrThreshold);
+        MinDiagnosisCount minDiagnosisCount = output.minDifferentialsToShow == null ? MinDiagnosisCount.notInitialized() : MinDiagnosisCount.setToUserDefinedMinCount(output.minDifferentialsToShow);
+        return new OutputOptions(lrThreshold, minDiagnosisCount, runConfiguration.pathogenicityThreshold,
+                output.displayAllVariants, output.outdir, prefix);
+    }
+}

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
@@ -9,14 +9,8 @@ import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
 import org.monarchinitiative.lirical.core.service.HpoTermSanitizer;
 import org.monarchinitiative.lirical.io.analysis.*;
 import org.monarchinitiative.phenol.ontology.data.TermId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -33,8 +27,6 @@ import java.util.Optional;
         mixinStandardHelpOptions = true,
         description = "Run LIRICAL from a Phenopacket.")
 public class PhenopacketCommand extends AbstractPrioritizeCommand {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PhenopacketCommand.class);
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
@@ -59,26 +51,7 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
     protected AnalysisData prepareAnalysisData(Lirical lirical,
                                                GenomeBuild genomeBuild,
                                                TranscriptDatabase transcriptDb) throws LiricalParseException {
-        LOGGER.info("Reading phenopacket from {}", phenopacketPath.toAbsolutePath());
-
-        PhenopacketData data = null;
-        try (InputStream is = new BufferedInputStream(new FileInputStream(phenopacketPath.toFile()))) {
-            PhenopacketImporter v2 = PhenopacketImporters.v2();
-            data = v2.read(is);
-            LOGGER.info("Success!");
-        } catch (PhenopacketImportException | IOException e) {
-            LOGGER.info("Unable to parse as v2 phenopacket, trying v1");
-        }
-
-        if (data == null) {
-            try (InputStream is = new BufferedInputStream(new FileInputStream(phenopacketPath.toFile()))) {
-                PhenopacketImporter v1 = PhenopacketImporters.v1();
-                data = v1.read(is);
-            } catch (PhenopacketImportException | IOException e) {
-                LOGGER.info("Unable to parse as v1 phenopacket");
-                throw new LiricalParseException("Unable to parse phenopacket from " + phenopacketPath.toAbsolutePath());
-            }
-        }
+        PhenopacketData data = PhenopacketUtil.readPhenopacketData(phenopacketPath);
 
         HpoTermSanitizer sanitizer = new HpoTermSanitizer(lirical.phenotypeService().hpo());
         List<TermId> presentTerms = data.getHpoTerms().map(sanitizer::replaceIfObsolete).flatMap(Optional::stream).toList();
@@ -87,14 +60,14 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
         // Read VCF file.
         GenesAndGenotypes genes;
         // Path to VCF set via CLI has priority.
-        Path vcfPath = this.vcfPath != null
+        Path vcf = this.vcfPath != null
                 ? this.vcfPath
                 : data.getVcfPath().orElse(null);
         String sampleId = data.getSampleId();
-        if (vcfPath == null) {
+        if (vcf == null) {
             genes = GenesAndGenotypes.empty();
         } else {
-            genes = readVariantsFromVcfFile(sampleId, vcfPath, genomeBuild, transcriptDb, lirical.variantParserFactory());
+            genes = readVariantsFromVcfFile(sampleId, vcf, genomeBuild, transcriptDb, lirical.variantParserFactory());
         }
         return AnalysisData.of(sampleId,
                 data.getAge().orElse(null),

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketUtil.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketUtil.java
@@ -1,0 +1,47 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
+import org.monarchinitiative.lirical.io.analysis.PhenopacketData;
+import org.monarchinitiative.lirical.io.analysis.PhenopacketImportException;
+import org.monarchinitiative.lirical.io.analysis.PhenopacketImporter;
+import org.monarchinitiative.lirical.io.analysis.PhenopacketImporters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class PhenopacketUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhenopacketUtil.class);
+
+    private PhenopacketUtil() {
+    }
+
+    public static PhenopacketData readPhenopacketData(Path phenopacket) throws LiricalParseException {
+        LOGGER.debug("Reading phenopacket from {}", phenopacket.toAbsolutePath());
+        PhenopacketData data = null;
+        try (InputStream is = new BufferedInputStream(Files.newInputStream(phenopacket))) {
+            PhenopacketImporter v2 = PhenopacketImporters.v2();
+            data = v2.read(is);
+            LOGGER.info("Success!");
+        } catch (PhenopacketImportException | IOException e) {
+            LOGGER.info("Unable to parse as v2 phenopacket, trying v1");
+        }
+
+        if (data == null) {
+            try (InputStream is = new BufferedInputStream(Files.newInputStream(phenopacket))) {
+                PhenopacketImporter v1 = PhenopacketImporters.v1();
+                data = v1.read(is);
+            } catch (PhenopacketImportException | IOException e) {
+                LOGGER.info("Unable to parse as v1 phenopacket");
+                throw new LiricalParseException("Unable to parse phenopacket from " + phenopacket.toAbsolutePath());
+            }
+        }
+        return data;
+    }
+
+}

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/ExperimentalCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/ExperimentalCommand.java
@@ -1,0 +1,22 @@
+package org.monarchinitiative.lirical.cli.cmd.experimental;
+
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "experimental",
+        hidden = true,
+        subcommands = {
+                PhenopacketsCommand.class,
+        },
+        sortOptions = false,
+        mixinStandardHelpOptions = true,
+        description = "Run experimental LIRICAL commands.")
+public class ExperimentalCommand implements Callable<Integer> {
+
+        @Override
+        public Integer call() {
+                // Work is done in subcommands.
+                return 0;
+        }
+}

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
@@ -1,0 +1,161 @@
+package org.monarchinitiative.lirical.cli.cmd.experimental;
+
+import org.monarchinitiative.lirical.cli.cmd.OutputCommand;
+import org.monarchinitiative.lirical.cli.cmd.PhenopacketUtil;
+import org.monarchinitiative.lirical.core.Lirical;
+import org.monarchinitiative.lirical.core.analysis.AnalysisData;
+import org.monarchinitiative.lirical.core.analysis.AnalysisOptions;
+import org.monarchinitiative.lirical.core.analysis.AnalysisResults;
+import org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner;
+import org.monarchinitiative.lirical.core.exception.LiricalException;
+import org.monarchinitiative.lirical.core.model.FilteringStats;
+import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
+import org.monarchinitiative.lirical.core.model.GenomeBuild;
+import org.monarchinitiative.lirical.core.output.*;
+import org.monarchinitiative.lirical.core.service.HpoTermSanitizer;
+import org.monarchinitiative.lirical.io.analysis.PhenopacketData;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Run LIRICAL in phenotype-only mode on a collection of phenopackets.
+ */
+@CommandLine.Command(name = "phenopackets",
+        sortOptions = false,
+        mixinStandardHelpOptions = true,
+        description = "Run LIRICAL for several phenopackets at once in phenotype-only mode.")
+public class PhenopacketsCommand extends OutputCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PhenopacketsCommand.class);
+
+    @CommandLine.Option(names = {"--assembly"},
+            paramLabel = "{hg19,hg38}",
+            description = "Genome build (default: ${DEFAULT-VALUE}).")
+    public String genomeBuild = "hg38";
+
+    @CommandLine.Parameters(
+            paramLabel = "phenopacket file(s)",
+            description = {
+                    "Input phenopacket(s).",
+            }
+    )
+    public List<Path> phenopacketPaths = null;
+
+    @Override
+    protected String getGenomeBuild() {
+        return genomeBuild;
+    }
+
+    @Override
+    protected Integer execute() {
+        long start = System.currentTimeMillis();
+        // 0 - check input
+        List<String> errors = checkInput();
+        if (!errors.isEmpty()) {
+            LOGGER.error("Errors:");
+            for (String error : errors)
+                LOGGER.error("  {}", error);
+            return 1;
+        }
+
+        Lirical lirical;
+        GenomeBuild genomeBuild;
+        try {
+            genomeBuild = parseGenomeBuild(getGenomeBuild());
+            LOGGER.debug("Using genome build {}", genomeBuild);
+            LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
+
+            // 1 - bootstrap the app
+            lirical = bootstrapLirical(genomeBuild);
+            LOGGER.info("Configured LIRICAL {}", lirical.version()
+                    .map("v%s"::formatted)
+                    .orElse(UNKNOWN_VERSION_PLACEHOLDER));
+        } catch (LiricalException e) {
+            LOGGER.error("Error: {}", e.getMessage());
+            LOGGER.debug("More info:", e);
+            return 1;
+        }
+
+        // Prepare objects required for the overall analysis
+        HpoTermSanitizer sanitizer = new HpoTermSanitizer(lirical.phenotypeService().hpo());
+
+        // 2 - process phenopackets
+        LOGGER.info("Processing {} phenopacket(s)", phenopacketPaths.size());
+        for (Path phenopacketPath : phenopacketPaths) {
+            try {
+                // prepare analysis data
+                LOGGER.info("Preparing analysis data for {}", phenopacketPath.toAbsolutePath());
+                PhenopacketData data = PhenopacketUtil.readPhenopacketData(phenopacketPath);
+
+                List<TermId> presentTerms = data.getHpoTerms().map(sanitizer::replaceIfObsolete).flatMap(Optional::stream).toList();
+                List<TermId> excludedTerms = data.getNegatedHpoTerms().map(sanitizer::replaceIfObsolete).flatMap(Optional::stream).toList();
+                if (presentTerms.isEmpty() && excludedTerms.isEmpty()) {
+                    LOGGER.warn("No phenotype terms were provided. Skipping..");
+                    continue;
+                }
+
+                AnalysisData analysisData = AnalysisData.of(data.getSampleId(),
+                        data.getAge().orElse(null),
+                        data.getSex().orElse(null),
+                        presentTerms,
+                        excludedTerms,
+                        GenesAndGenotypes.empty());
+
+                LOGGER.info("Running the analysis");
+                AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild, runConfiguration.transcriptDb);
+                LiricalAnalysisRunner analysisRunner = lirical.analysisRunner();
+                AnalysisResults results = analysisRunner.run(analysisData, analysisOptions);
+
+                LOGGER.info("Writing out the results");
+                FilteringStats filteringStats = analysisData.genes().computeFilteringStats();
+                AnalysisResultsMetadata metadata = AnalysisResultsMetadata.builder()
+                        .setLiricalVersion(lirical.version().orElse(UNKNOWN_VERSION_PLACEHOLDER))
+                        .setHpoVersion(lirical.phenotypeService().hpo().version().orElse(UNKNOWN_VERSION_PLACEHOLDER))
+                        .setTranscriptDatabase(runConfiguration.transcriptDb.toString())
+                        .setLiricalPath(dataSection.liricalDataDirectory.toAbsolutePath().toString())
+                        .setExomiserPath(dataSection.exomiserDatabase == null ? "" : dataSection.exomiserDatabase.toAbsolutePath().toString())
+                        .setAnalysisDate(LocalDateTime.now().toString())
+                        .setSampleName(analysisData.sampleId())
+                        .setnGoodQualityVariants(filteringStats.nGoodQualityVariants())
+                        .setnFilteredVariants(filteringStats.nFilteredVariants())
+                        .setGenesWithVar(0) // TODO
+                        .setGlobalMode(runConfiguration.globalAnalysisMode)
+                        .build();
+
+                AnalysisResultWriterFactory factory = lirical.analysisResultsWriterFactory();
+
+                OutputOptions outputOptions = createOutputOptions(data.getSampleId());
+                for (OutputFormat fmt : output.outputFormats) {
+                    Optional<AnalysisResultsWriter> writer = factory.getWriter(fmt);
+                    if (writer.isPresent()) {
+                        writer.get().process(analysisData, results, metadata, outputOptions);
+                    }
+                }
+            } catch (IOException | LiricalException e) {
+                LOGGER.error("Error processing {}: {}", phenopacketPath.toAbsolutePath(), e.getMessage());
+                LOGGER.debug("More info:", e);
+                return 1;
+            }
+        }
+        reportElapsedTime(start, System.currentTimeMillis());
+
+        return 0;
+    }
+
+    protected List<String> checkInput() {
+        List<String> errors = super.checkInput();
+
+        if (phenopacketPaths == null || phenopacketPaths.isEmpty())
+            errors.add("At least one phenopacket path must be provided");
+
+        return errors;
+    }
+}

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/package-info.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package with experimental LIRICAL commands. The commands are hidden from the public CLI.
+ */
+package org.monarchinitiative.lirical.cli.cmd.experimental;


### PR DESCRIPTION
Add `experimental phenopackets` command for running LIRICAL in phenotype-only mode on a collection of phenopackets.