### PR TITLE
Enhance genotype LR matching

### DIFF
--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
@@ -112,7 +112,7 @@ public class GenotypeLikelihoodRatio {
         }
         // special case 2: Clinvar-pathogenic variant(s) found in this gene.
         // The likelihood ratio is defined as 1000**count, where 1 for autosomal dominant and
-        // 2 for autosomal recessive. (If the count of pathogenic alleles does not match
+        // 2 for autosomal recessive. If the count of pathogenic alleles does not match
         // the expected count, return 1000.
 
         int pathogenicClinVarAlleleCount = g2g.pathogenicClinVarCount(sampleId);

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLrMatchType.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLrMatchType.java
@@ -1,0 +1,59 @@
+package org.monarchinitiative.lirical.core.likelihoodratio;
+
+/**
+ * The enum for representing the type of the genotype likelihood ratio analysis performed for a gene.
+ *
+ * @see GenotypeLrWithExplanation
+ */
+public enum GenotypeLrMatchType {
+
+    /**
+     * No variants were detected in a gene associated with a disease with autosomal dominant inheritance.
+     */
+    NO_VARIANTS_DETECTED_AD,
+
+    /**
+     * No variants were detected in a gene associated with a disease with autosomal recessive inheritance.
+     */
+    NO_VARIANTS_DETECTED_AR,
+
+    /**
+     * One ClinVar pathogenic or likely pathogenic variant discovered in a disease
+     * with autosomal dominant inheritance.
+     */
+    ONE_DELETERIOUS_CLINVAR_VARIANT_IN_AD,
+
+    /**
+     * Two ClinVar pathogenic or likely pathogenic variants discovered in a disease
+     * with autosomal recessive inheritance.
+     */
+    TWO_DELETERIOUS_CLINVAR_VARIANTS_IN_AR,
+
+    /**
+     * One deleterious allele detected with autosomal recessive disease.
+     */
+    ONE_DELETERIOUS_VARIANT_IN_AR,
+
+    /**
+     * Heuristic for the case where we have more called pathogenic variants than we should have
+     * in a gene without a high background count -- we will model this as technical error and
+     * will take the observed path weighted count to not be more than &lambda;<sub>disease</sub>.
+     * this will have the effect of not down-weighting these genes
+     * the user will have to judge whether one of the variants is truly pathogenic.
+     */
+    HIGH_NUMBER_OF_OBSERVED_PREDICTED_PATHOGENIC_VARIANTS,
+
+    /**
+     * Gene scored using LIRICAL genotype LR model.
+     */
+    LIRICAL_GT_MODEL,
+
+    /**
+     * DO NOT USE. A placeholder value used in the deprecated methods for backward compatibility.
+     *
+     * @deprecated the field will be removed in <code>v3.0.0</code>.
+     */
+    @Deprecated(forRemoval = true)
+    // REMOVE(v3.0.0)
+    UNKNOWN
+}

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLrWithExplanation.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLrWithExplanation.java
@@ -6,10 +6,12 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.Objects;
 
-
+/**
+ * Results of genotype likelihood ratio evaluation for a single gene.
+ */
 public class GenotypeLrWithExplanation  {
     private final GeneIdentifier geneId;
-    /** The likelihood ratio of the genotype. */
+    /** The untransformed likelihood ratio of the genotype. */
     private final double lr;
     private final String explanation;
 
@@ -87,15 +89,34 @@ public class GenotypeLrWithExplanation  {
         this.explanation = Objects.requireNonNull(explanation, "Explanation must not be null");
     }
 
-
+    /**
+     * Get the gene identifier for this genotype LR.
+     */
     public GeneIdentifier geneId() {
         return geneId;
     }
 
+    /**
+     * Get the genotype likelihood ratio for the gene. Use {@link #log10Lr()} to get the log LR.
+     *
+     * @return the genotype likelihood ratio
+     */
     public double lr() {
         return lr;
     }
 
+    /**
+     * Get the log<sub>10</sub> LR for the gene. Use {@link #lr()} to get the non-transformed value.
+     *
+     * @return the log<sub>10</sub> of the genotype LR
+     */
+    public double log10Lr() {
+        return Math.log10(lr);
+    }
+
+    /**
+     * @return an explanation of the genotype likelihood ratio
+     */
     public String explanation() {
         return explanation;
     }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinVarAlleleData.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinVarAlleleData.java
@@ -1,0 +1,73 @@
+package org.monarchinitiative.lirical.core.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A subset of ClinVar allele data relevant for LIRICAL analysis.
+ * <p>
+ * We use the primary interpretation for prioritization and the allele ID for linking out
+ * (e.g. <a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=270003[alleleid]">here</a> for an allele ID <code>270003</code>)
+ */
+public class ClinVarAlleleData {
+
+    private final ClinvarClnSig clinvarClnSig;
+    private final Long alleleId; // we box since the alleleId is nullable.
+
+    public static ClinVarAlleleData of(ClinvarClnSig clinvarClnSig, Long alleleId) {
+        return new ClinVarAlleleData(clinvarClnSig, alleleId);
+    }
+
+    private ClinVarAlleleData(ClinvarClnSig clinvarClnSig, Long alleleId) {
+        this.clinvarClnSig = Objects.requireNonNull(clinvarClnSig);
+        this.alleleId = alleleId; // nullable
+    }
+
+    /**
+     * @return the primary interpretation of the ClinVar data for the variant
+     */
+    public ClinvarClnSig getClinvarClnSig() {
+        return clinvarClnSig;
+    }
+
+    /**
+     * Get ClinVar <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/identifiers/#allele">allele ID</a>.
+     * <p>
+     * E.g.
+     *
+     *
+     * @return an {@linkplain Optional} ClinVar allele ID {@linkplain Long} or an empty {@linkplain Optional}.
+     */
+    public Optional<Long> getAlleleId() {
+        return Optional.ofNullable(alleleId);
+    }
+
+    /**
+     * @return ClinVar allele ID as {@linkplain String}
+     * @see #getAlleleId()
+     */
+    public Optional<String> getAlleleIdString() {
+        return alleleId == null ? Optional.empty() : Optional.of(alleleId.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClinVarAlleleData that = (ClinVarAlleleData) o;
+        return clinvarClnSig == that.clinvarClnSig && Objects.equals(alleleId, that.alleleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clinvarClnSig, alleleId);
+    }
+
+    @Override
+    public String toString() {
+        return "ClinVarAlleleData{" +
+                "clinvarClnSig=" + clinvarClnSig +
+                ", alleleId=" + alleleId +
+                '}';
+    }
+}

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinvarClnSig.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/ClinvarClnSig.java
@@ -31,4 +31,21 @@ public enum ClinvarClnSig {
             default -> false;
         };
     }
+
+    /**
+     * @return {@code true} if the significance is one of {@link #BENIGN}, {@link #LIKELY_BENIGN}, or {@link #BENIGN_OR_LIKELY_BENIGN}
+     */
+    public boolean isBenignOrLikelyBenign() {
+        return switch (this) {
+            case BENIGN, LIKELY_BENIGN, BENIGN_OR_LIKELY_BENIGN -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * @return {@code false} if the significance is one of {@link #BENIGN}, {@link #LIKELY_BENIGN}, or {@link #BENIGN_OR_LIKELY_BENIGN}
+     */
+    public boolean notBenignOrLikelyBenign() {
+        return !isBenignOrLikelyBenign();
+    }
 }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/LiricalVariantDefault.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/LiricalVariantDefault.java
@@ -54,8 +54,8 @@ class LiricalVariantDefault implements LiricalVariant {
     }
 
     @Override
-    public ClinvarClnSig clinvarClnSig() {
-        return variantMetadata.clinvarClnSig();
+    public Optional<ClinVarAlleleData> clinVarAlleleData() {
+        return variantMetadata.clinVarAlleleData();
     }
 
     @Override

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadata.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadata.java
@@ -8,12 +8,21 @@ public interface VariantMetadata {
         return VariantMetadataDefault.empty();
     }
 
+    /**
+     * @deprecated from {@code 2.0.0-RC3}. Use {@link #of(float, float, ClinVarAlleleData)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "2.0.0-RC3")
     static VariantMetadata of(float frequency,
                               float pathogenicity,
                               ClinvarClnSig clinvarClnSig) {
-        return new VariantMetadataDefault(frequency,
-                pathogenicity,
-                clinvarClnSig);
+        ClinVarAlleleData data = ClinVarAlleleData.of(clinvarClnSig, null);
+        return of(frequency, pathogenicity, data);
+    }
+
+    static VariantMetadata of(float frequency,
+                              float pathogenicity,
+                              ClinVarAlleleData clinVarAlleleData) {
+        return new VariantMetadataDefault(frequency, pathogenicity, clinVarAlleleData);
     }
 
     /**
@@ -56,9 +65,21 @@ public interface VariantMetadata {
     }
 
     /**
+     * @deprecated since <code>2.0.0-RC3</code> and will be removed in <code>v3.0.0</code>. Use {@link #clinVarAlleleData()} instead.
      * @return Clinvar clinical significance category.
      */
-    ClinvarClnSig clinvarClnSig();
+    // REMOVE(v3.0.0)
+    @Deprecated(forRemoval = true, since = "2.0.0-RC3")
+    default ClinvarClnSig clinvarClnSig() {
+        return clinVarAlleleData()
+                .map(ClinVarAlleleData::getClinvarClnSig)
+                .orElse(ClinvarClnSig.NOT_PROVIDED);
+    }
+
+    /**
+     * @return <code>ClinvarData</code> for the variant, if available.
+     */
+    Optional<ClinVarAlleleData> clinVarAlleleData();
 
     /**
      * This is the frequency factor used for the Exomiser like pathogenicity score. It penalizes variants that have a higher

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadataDefault.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/VariantMetadataDefault.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 class VariantMetadataDefault implements VariantMetadata {
 
-    private static final VariantMetadataDefault EMPTY = new VariantMetadataDefault(Float.NaN, Float.NaN, ClinvarClnSig.NOT_PROVIDED);
+    private static final VariantMetadataDefault EMPTY = new VariantMetadataDefault(Float.NaN, Float.NaN, null);
 
     static VariantMetadataDefault empty() {
         return EMPTY;
@@ -13,14 +13,14 @@ class VariantMetadataDefault implements VariantMetadata {
 
     private final float frequency;
     private final float pathogenicity;
-    private final ClinvarClnSig clinvarClnSig;
+    private final ClinVarAlleleData clinVarAlleleData;
 
     VariantMetadataDefault(float frequency,
                            float pathogenicity,
-                           ClinvarClnSig clinvarClnSig) {
+                           ClinVarAlleleData clinVarAlleleData) {
         this.frequency = frequency;
         this.pathogenicity = pathogenicity;
-        this.clinvarClnSig = Objects.requireNonNull(clinvarClnSig);
+        this.clinVarAlleleData = clinVarAlleleData; // nullable
     }
 
     @Override
@@ -36,8 +36,8 @@ class VariantMetadataDefault implements VariantMetadata {
     }
 
     @Override
-    public ClinvarClnSig clinvarClnSig() {
-        return clinvarClnSig;
+    public Optional<ClinVarAlleleData> clinVarAlleleData() {
+        return Optional.ofNullable(clinVarAlleleData);
     }
 
     @Override
@@ -45,7 +45,7 @@ class VariantMetadataDefault implements VariantMetadata {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         VariantMetadataDefault that = (VariantMetadataDefault) o;
-        return Float.compare(that.frequency, frequency) == 0 && Float.compare(that.pathogenicity, pathogenicity) == 0 && Objects.equals(clinvarClnSig, that.clinvarClnSig);
+        return Float.compare(that.frequency, frequency) == 0 && Float.compare(that.pathogenicity, pathogenicity) == 0 && Objects.equals(clinVarAlleleData, that.clinVarAlleleData);
     }
 
     @Override
@@ -58,7 +58,7 @@ class VariantMetadataDefault implements VariantMetadata {
         return "VariantMetadataDefault{" +
                 "frequency=" + frequency +
                 ", pathogenicity=" + pathogenicity +
-                ", clinvarClnSig=" + clinvarClnSig +
+                ", clinvarClnSig=" + clinVarAlleleData +
                 '}';
     }
 }

--- a/lirical-core/src/test/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatioTest.java
+++ b/lirical-core/src/test/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatioTest.java
@@ -48,6 +48,7 @@ public class GenotypeLikelihoodRatioTest {
         Gene2Genotype g2g = setupGeneToGenotype(MADE_UP_GENE, 1, 1, 0.8);
         GenotypeLikelihoodRatio glr = new GenotypeLikelihoodRatio(BackgroundVariantFrequencyService.of(Map.of(), 0.1), OPTIONS);
         GenotypeLrWithExplanation gle = glr.evaluateGenotype(SAMPLE_ID, g2g, List.of(AUTOSOMAL_DOMINANT));
+        assertThat(gle.matchType(), equalTo(GenotypeLrMatchType.ONE_DELETERIOUS_CLINVAR_VARIANT_IN_AD));
         Assertions.assertEquals(1000, gle.lr(), EPSILON);
     }
 
@@ -62,6 +63,7 @@ public class GenotypeLikelihoodRatioTest {
         GenotypeLikelihoodRatio glr = new GenotypeLikelihoodRatio(BackgroundVariantFrequencyService.of(Map.of(), 0.1), OPTIONS);
         GenotypeLrWithExplanation gle = glr.evaluateGenotype(SAMPLE_ID, g2g, List.of(AUTOSOMAL_RECESSIVE));
 
+        assertThat(gle.matchType(), equalTo(GenotypeLrMatchType.TWO_DELETERIOUS_CLINVAR_VARIANTS_IN_AR));
         Assertions.assertEquals(1000. * 1000, gle.lr(), EPSILON);
     }
 
@@ -80,6 +82,7 @@ public class GenotypeLikelihoodRatioTest {
         GenotypeLikelihoodRatio glr = new GenotypeLikelihoodRatio(BackgroundVariantFrequencyService.of(background, 0.1), OPTIONS);
         GenotypeLrWithExplanation gle = glr.evaluateGenotype(SAMPLE_ID, g2g, List.of(AUTOSOMAL_DOMINANT));
         // heuristic score
+        assertThat(gle.matchType(), equalTo(GenotypeLrMatchType.NO_VARIANTS_DETECTED_AD));
         Assertions.assertEquals(0.05, gle.lr(), EPSILON);
     }
 
@@ -97,6 +100,7 @@ public class GenotypeLikelihoodRatioTest {
         GenotypeLikelihoodRatio glr = new GenotypeLikelihoodRatio(BackgroundVariantFrequencyService.of(g2background, 0.1), OPTIONS);
         GenotypeLrWithExplanation gle = glr.evaluateGenotype(SAMPLE_ID, g2g, List.of(AUTOSOMAL_RECESSIVE));
         // heuristic score for AR
+        assertThat(gle.matchType(), equalTo(GenotypeLrMatchType.NO_VARIANTS_DETECTED_AR));
         Assertions.assertEquals(0.05 * 0.05, gle.lr(), EPSILON);
     }
 
@@ -118,6 +122,7 @@ public class GenotypeLikelihoodRatioTest {
 
         // TODO - check
         assertThat(gle.geneId(), equalTo(thrbId));
+        assertThat(gle.matchType(), equalTo(GenotypeLrMatchType.LIRICAL_GT_MODEL));
         assertThat(gle.lr(), is(closeTo(1.719420800179587e109, EPSILON)));
         assertThat(gle.explanation(), equalTo("log<sub>10</sub>(LR)=109.235 P(G|D)=0.0000. P(G|&#172;D)=0.0000.  Mode of inheritance: autosomal recessive. Observed weighted pathogenic variant count: 44.80. &lambda;<sub>disease</sub>=2. &lambda;<sub>background</sub>=0.0070."));
     }

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/serialize/GenotypeLrWithExplanationSerializer.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/serialize/GenotypeLrWithExplanationSerializer.java
@@ -22,6 +22,7 @@ public class GenotypeLrWithExplanationSerializer extends StdSerializer<GenotypeL
         gen.writeStartObject();
 
         gen.writeObjectField("geneId", value.geneId());
+        gen.writeObjectField("matchType", value.matchType());
         gen.writeNumberField("lr", value.lr());
         gen.writeStringField("explanation", value.explanation());
 

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/output/JsonAnalysisResultWriterTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/output/JsonAnalysisResultWriterTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.monarchinitiative.lirical.core.analysis.AnalysisData;
 import org.monarchinitiative.lirical.core.analysis.AnalysisResults;
 import org.monarchinitiative.lirical.core.analysis.TestResult;
+import org.monarchinitiative.lirical.core.likelihoodratio.GenotypeLrMatchType;
 import org.monarchinitiative.lirical.core.likelihoodratio.GenotypeLrWithExplanation;
 import org.monarchinitiative.lirical.core.likelihoodratio.LrMatchType;
 import org.monarchinitiative.lirical.core.likelihoodratio.LrWithExplanation;
@@ -74,7 +75,11 @@ public class JsonAnalysisResultWriterTest {
     private static AnalysisResults createTestAnalysisResults() {
         List<LrWithExplanation> observed = List.of(LrWithExplanation.of(a, b, LrMatchType.EXACT_MATCH, 1.34, "EXPLANATION"));
         List<LrWithExplanation> excluded = List.of(LrWithExplanation.of(a, c, LrMatchType.EXCLUDED_QUERY_TERM_NOT_PRESENT_IN_DISEASE, 1.23, "EXCLUDED_EXPLANATION"));
-        GenotypeLrWithExplanation genotypeLr = GenotypeLrWithExplanation.of(GeneIdentifier.of(TermId.of("NCBIGene:1234"), "GENE_SYMBOL"), 1.23, "GENE_EXPLANATION");
+        GenotypeLrWithExplanation genotypeLr = GenotypeLrWithExplanation.of(
+                GeneIdentifier.of(TermId.of("NCBIGene:1234"), "GENE_SYMBOL"),
+                GenotypeLrMatchType.LIRICAL_GT_MODEL,
+                1.23,
+                "GENE_EXPLANATION");
         return AnalysisResults.of(
                 List.of(
                         TestResult.of(


### PR DESCRIPTION
The PR adds more information to `GenotypeLrWithExplanation` to allow better explanation of genotype LRs downstream. 

The new enum `GenotypeLrMatchType` is conceptually similar to `LrMatchType` and describes the route of genotype LR calculation. Based on the enum value, the downstream code can determine how many causal variants need to be searched for and presented in the report.

@pnrobinson while working with the code, I also wanted to address #616 . Basically, we will ***NEVER*** include the variants with primary ClinVar interpretation from one of the following into consideration, when calculating the number of pathogenic alleles or pathogenicity bin score for a gene:
- BENIGN
- LIKELY_BENIGN
- BENIGN_OR_LIKELY_BENIGN

@pnrobinson can you please comment if this is what you wanted in #616, #592 and #586 ?