### PR TITLE
Enhance output formats

### DIFF
--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -70,7 +70,7 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
                     .setHpoVersion(lirical.phenotypeService().hpo().version().orElse(UNKNOWN_VERSION_PLACEHOLDER))
                     .setTranscriptDatabase(transcriptDb.toString())
                     .setLiricalPath(dataSection.liricalDataDirectory.toAbsolutePath().toString())
-                    .setExomiserPath(dataSection.exomiserDatabase == null ? "" : dataSection.exomiserDatabase.toAbsolutePath().toString())
+                    .setExomiserPath(figureOutExomiserPath())
                     .setAnalysisDate(LocalDateTime.now().toString())
                     .setSampleName(analysisData.sampleId())
                     .setnPassingVariants(filteringStats.nPassingVariants())
@@ -96,6 +96,18 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
         }
 
         return 0;
+    }
+
+    private String figureOutExomiserPath() {
+        if (dataSection.exomiserHg19Database == null && dataSection.exomiserHg38Database == null) {
+            return "";
+        } else {
+            if (dataSection.exomiserHg19Database == null) {
+                return dataSection.exomiserHg38Database.toAbsolutePath().toString();
+            } else {
+                return dataSection.exomiserHg19Database.toAbsolutePath().toString();
+            }
+        }
     }
 
     protected abstract AnalysisData prepareAnalysisData(Lirical lirical, GenomeBuild genomeBuild, TranscriptDatabase transcriptDb) throws LiricalParseException;

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/HtmlTemplate.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/HtmlTemplate.java
@@ -72,11 +72,7 @@ public class HtmlTemplate extends LiricalTemplate {
         int N = totalDetailedDiagnosesToShow(analysisResults);
         List<SparklinePacket> sparklinePackets = SparklinePacket.sparklineFactory(analysisResults, diseases, hpo, N);
         this.templateData.put("sparkline", sparklinePackets);
-        this.templateData.put("hasGenotypes", "true");
-        if (symbolsWithoutGeneIds == null || symbolsWithoutGeneIds.isEmpty()) {
-            this.templateData.put("hasGeneSymbolsWithoutIds", "false");
-        } else {
-            this.templateData.put("hasGeneSymbolsWithoutIds", "true");
+        if (symbolsWithoutGeneIds != null && !symbolsWithoutGeneIds.isEmpty()) {
             this.templateData.put("geneSymbolsWithoutIds", symbolsWithoutGeneIds);
         }
         Map<TermId, HpoDisease> diseaseById = diseases.diseaseById();

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/LiricalTemplate.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/LiricalTemplate.java
@@ -11,8 +11,6 @@ import org.monarchinitiative.lirical.core.output.OutputOptions;
 import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,7 +25,6 @@ import java.util.stream.Collectors;
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
 public abstract class LiricalTemplate {
-    private static final Logger logger = LoggerFactory.getLogger(LiricalTemplate.class);
 
     private final AnalysisData analysisData;
     /** Map of data that will be used for the FreeMark template. */
@@ -75,7 +72,7 @@ public abstract class LiricalTemplate {
             String tstr = String.format("%s <a href=\"https://hpo.jax.org/app/browse/term/%s\">%s</a>",termName,id.getValue(),id.getValue());
             observedHPOs.add(tstr);
         }
-        this.templateData.put("observedHPOs",observedHPOs);
+        templateData.put("observedHPOs",observedHPOs);
         List<String> excludedHpos = new ArrayList<>();
         for (TermId id:analysisData.negatedPhenotypeTerms()) {
             String termName = ontology.termForTermId(id)
@@ -84,12 +81,10 @@ public abstract class LiricalTemplate {
             String tstr = String.format("%s <a href=\"https://hpo.jax.org/app/browse/term/%s\">%s</a>",termName,id.getValue(),id.getValue());
             excludedHpos.add(tstr);
         }
-        this.templateData.put("excludedHPOs",excludedHpos);
-        // This is a flag for the output to only show the list if there are some phenotypes that were excluded in the
-        // proband.
-        if (!excludedHpos.isEmpty()) {
-            this.templateData.put("hasExcludedHPOs","true");
-        }
+        templateData.put("excludedHPOs",excludedHpos);
+        // Indicates that LIRICAL was run without a VCF file.
+        templateData.put("phenotypeOnly", analysisData.genes().size() == 0);
+
     }
 
     /** Some of our name strings contain multiple synonyms. This function removes all but the first.*/
@@ -100,8 +95,6 @@ public abstract class LiricalTemplate {
         else
             return name;
     }
-
-    public Path getOutPath() { return outputPath;}
 
     protected static Path createOutputFile(Path outdir, String prefix, String format) {
         if (!Files.isDirectory(outdir))

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/TsvTemplate.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/output/TsvTemplate.java
@@ -31,9 +31,6 @@ import java.util.stream.Stream;
 public class TsvTemplate extends LiricalTemplate {
     private static final Logger logger = LoggerFactory.getLogger(TsvTemplate.class);
 
-    private static final String[] tsvHeader = {"rank", "diseaseName", "diseaseCurie", "pretestprob", "posttestprob",
-            "compositeLR", "entrezGeneId", "variants"};
-
     TsvTemplate(MinimalOntology hpo,
                 HpoDiseases diseases,
                 AnalysisData analysisData,
@@ -42,7 +39,6 @@ public class TsvTemplate extends LiricalTemplate {
                 OutputOptions outputOptions) {
         super(hpo, analysisData, resultsMetadata, outputOptions);
         cfg.setClassForTemplateLoading(TsvTemplate.class, "");
-        templateData.put("header", String.join("\t", tsvHeader));
         AtomicInteger rank = new AtomicInteger();
         Map<TermId, HpoDisease> diseaseById = diseases.diseaseById();
         List<TsvDifferential> diff = new ArrayList<>();

--- a/lirical-io/src/main/resources/org/monarchinitiative/lirical/io/output/liricalHTML.ftl
+++ b/lirical-io/src/main/resources/org/monarchinitiative/lirical/io/output/liricalHTML.ftl
@@ -470,7 +470,7 @@
 <main>
     <section class="sample-summary elevate-container">
         <a id="Phenotypes"></a>
-        <h1 class="center">${resultsMeta.sampleName!"n/a"} Phenotypic Features</h1>
+        <h1 class="center">Phenotypic features of ${resultsMeta.sampleName!"n/a"}</h1>
         <article>
             <div class="row">
                 <div class="column features-title center">
@@ -533,8 +533,29 @@
                 <p>${topdifferentialcount}</p>
             </div>
             <div style="text-align:center;">
-                <#if hasGenotypes?has_content>
+                <#if phenotypeOnly>
                     <table class="posttest">
+                        <tr>
+                            <th>Rank</th>
+                            <th>Post-test probability</th>
+                            <th>Disease</th>
+                            <th>ID</th>
+                            <th>Phenotypes</th>
+                            <th>LR (log<sub>10</sub>)</th>
+                        </tr>
+                        <#list sparkline as sprk>
+                            <tr>
+                                <td class="posttest">${sprk.rank}</td>
+                                <td>${sprk.posttestBarSvg}</td>
+                                <td><a href="#diagnosis${sprk.rank}">${sprk.diseaseName}</a></td>
+                                <td>${sprk.diseaseAnchor}</td>
+                                <td>${sprk.sparklineSvg}</td>
+                                <td class="posttest">${sprk.compositeLikelihoodRatio}</td>
+                            </tr>
+                        </#list>
+                    </table>
+                <#else>
+                     <table class="posttest">
                         <tr>
                             <th>Rank</th>
                             <th>Post-test probability</th>
@@ -550,27 +571,6 @@
                                 <td><a href="#diagnosis${sprk.rank}">${sprk.diseaseName}</a></td>
                                 <td>${sprk.sparklineSvg}</td>
                                 <td class="posttest">${sprk.geneSparklineSvg}</td>
-                                <td class="posttest">${sprk.compositeLikelihoodRatio}</td>
-                            </tr>
-                        </#list>
-                    </table>
-                <#else>
-                    <table class="posttest">
-                        <tr>
-                            <th>Rank</th>
-                            <th>Post-test probability</th>
-                            <th>Disease</th>
-                            <th>ID</th>
-                            <th>Phenotypes</th>
-                            <th>LR (log)</th>
-                        </tr>
-                        <#list sparkline as sprk>
-                            <tr>
-                                <td class="posttest">${sprk.rank}</td>
-                                <td>${sprk.posttestBarSvg}</td>
-                                <td><a href="#diagnosis${sprk.rank}">${sprk.diseaseName}</a></td>
-                                <td>${sprk.diseaseAnchor}</td>
-                                <td>${sprk.sparklineSvg}</td>
                                 <td class="posttest">${sprk.compositeLikelihoodRatio}</td>
                             </tr>
                         </#list>
@@ -775,29 +775,31 @@
 
             <h4><i>This LIRICAL run had the following configuration:</i></h4>
             <ul>
+                <#if resultsMeta.liricalPath?has_content>
+                    <li>Path to LIRICAL data directory: ${resultsMeta.liricalPath}</li>
+                </#if>
                 <#if resultsMeta.hpoVersion?has_content>
                     <li>Human Phenotype Ontology version: ${resultsMeta.hpoVersion}</li>
                 </#if>
-                <#if resultsMeta.transcriptDatabase?has_content>
-                    <li>Transcript database: ${resultsMeta.transcriptDatabase}</li>
-                </#if>
-                <#if resultsMeta.nPassingVariants?has_content>
-                    <li>Good quality variants: ${resultsMeta.nPassingVariants}</li>
-                </#if>
-                <#if resultsMeta.nFilteredVariants?has_content>
-                    <li>Variants removed due to failing quality filter: ${resultsMeta.nFilteredVariants}</li>
-                </#if>
-                <#if resultsMeta.genesWithVar?has_content>
-                    <li>Genes found to have at least one variant: ${resultsMeta.genesWithVar}</li>
-                </#if>
-                <#if resultsMeta.liricalPath?has_content>
-                    <li>Path to Lirical data directory: ${resultsMeta.liricalPath}</li>
-                </#if>
-                <#if resultsMeta.exomiserPath?has_content>
-                    <li>Path to Exomiser data directory: ${resultsMeta.exomiserPath}</li>
-                </#if>
                 <#if resultsMeta.globalMode?has_content>
                     <li>Global analysis mode: ${resultsMeta.globalMode?string("Yes", "No")}</li>
+                </#if>
+                <#if !phenotypeOnly>
+                    <#if resultsMeta.transcriptDatabase?has_content>
+                        <li>Transcript database: ${resultsMeta.transcriptDatabase}</li>
+                    </#if>
+                    <#if resultsMeta.exomiserPath?has_content>
+                        <li>Path to Exomiser database file: ${resultsMeta.exomiserPath}</li>
+                    </#if>
+                    <#if resultsMeta.nPassingVariants?has_content>
+                        <li>Good quality variants: ${resultsMeta.nPassingVariants}</li>
+                    </#if>
+                    <#if resultsMeta.nFilteredVariants?has_content>
+                        <li>Variants removed due to failing quality filter: ${resultsMeta.nFilteredVariants}</li>
+                    </#if>
+                    <#if resultsMeta.genesWithVar?has_content>
+                        <li>Genes found to have at least one variant: ${resultsMeta.genesWithVar}</li>
+                    </#if>
                 </#if>
             </ul>
             </p>

--- a/lirical-io/src/main/resources/org/monarchinitiative/lirical/io/output/liricalTSV.ftl
+++ b/lirical-io/src/main/resources/org/monarchinitiative/lirical/io/output/liricalTSV.ftl
@@ -1,11 +1,26 @@
 ! LIRICAL TSV Output (${resultsMeta.liricalVersion})
 ! Sample: ${resultsMeta.sampleName!"n/a"}
-! Observed HPO terms
-<#assign tab="\t">
-<#list  observedHPOs as hpo>
-! ${hpo}
+<#if observedHPOs?has_content>
+! Observed HPO terms:
+<#list observedHPOs as obs_hpo>
+!  ${obs_hpo}
 </#list>
-${header}
+</#if>
+<#if excludedHPOs?has_content>
+! Excluded HPO terms:
+<#list excludedHPOs as ex_hpo>
+!  ${ex_hpo}
+</#list>
+</#if>
+<#assign tab="\t">
+<#if phenotypeOnly>
+rank${tab}diseaseName${tab}diseaseCurie${tab}pretestprob${tab}posttestprob${tab}compositeLR
+<#list diff as dd>
+${dd.rank}${tab}${dd.diseaseName}${tab}${dd.diseaseCurie}${tab}${dd.pretestprob}${tab}${dd.posttestprob}${tab}${dd.compositeLR}
+</#list>
+<#else>
+rank${tab}diseaseName${tab}diseaseCurie${tab}pretestprob${tab}posttestprob${tab}compositeLR${tab}${tab}entrezGeneId${tab}variants
 <#list diff as dd>
 ${dd.rank}${tab}${dd.diseaseName}${tab}${dd.diseaseCurie}${tab}${dd.pretestprob}${tab}${dd.posttestprob}${tab}${dd.compositeLR}${tab}${dd.entrezGeneId}${tab}${dd.varString}
 </#list>
+</#if>


### PR DESCRIPTION
Improve HTML and TSV outputs.

The HTML report now reports variant-related metadata only if the analysis was run with a VCF file.

The TSV report includes genes and variants only if run with a VCF file.

The HTML and TSV templates were simplified.

Fixes #609 