### PR TITLE
Simplify handling of subject's age

### DIFF
--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/LiricalOptions.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/LiricalOptions.java
@@ -3,7 +3,9 @@ package org.monarchinitiative.lirical.core;
 import java.util.Optional;
 
 /**
- * Options of the LIRICAL process that live independent of the analyses.
+ * Global options to parameterize LIRICAL execution.
+ * <p>
+ * Note, these options do <em>not</em> parameterize the analyses.
  */
 public class LiricalOptions {
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisData.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisData.java
@@ -9,24 +9,34 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 
 /**
- * An interface for representing proband data.
+ * Representation of subject data required by LIRICAL analysis.
  */
 public interface AnalysisData {
 
+    /**
+     * Construct analysis data from the inputs.
+     *
+     * @param sampleId non-null sample identifier.
+     * @param age subject's age or {@code null} if not available.
+     * @param sex non-null sex.
+     * @param presentPhenotypeTerms a collection of observed HPO terms.
+     * @param negatedPhenotypeTerms a collection of excluded HPO terms.
+     * @param genes non-null container of genes and genotypes.
+     */
     static AnalysisData of(String sampleId,
                            Age age,
                            Sex sex,
                            Collection<TermId> presentPhenotypeTerms,
                            Collection<TermId> negatedPhenotypeTerms,
                            GenesAndGenotypes genes) {
-        return new AnalysisDataDefault(Objects.requireNonNull(sampleId),
+        return new AnalysisDataDefault(sampleId,
                 age,
-                Objects.requireNonNull(sex),
-                List.copyOf(Objects.requireNonNull(presentPhenotypeTerms)),
-                List.copyOf(Objects.requireNonNull(negatedPhenotypeTerms)),
+                sex,
+                presentPhenotypeTerms,
+                negatedPhenotypeTerms,
                 genes);
     }
 
@@ -35,17 +45,31 @@ public interface AnalysisData {
      */
     String sampleId();
 
-    // TODO - make non-null or wrap into Optional. See the TODO in Age for more info.
-    Age age();
+    /**
+     * @return an optional with age or empty optional if age is not available.
+     */
+    Optional<Age> age();
 
+    /**
+     * @return a non-null sex of the subject.
+     */
     Sex sex();
 
+    /**
+     * @return a list of the HPO terms that were observed in the subject.
+     */
     @JsonGetter(value = "observedPhenotypicFeatures")
     List<TermId> presentPhenotypeTerms();
 
+    /**
+     * @return a list of the HPO terms whose presence was explicitly excluded in the subject.
+     */
     @JsonGetter(value = "excludedPhenotypicFeatures")
     List<TermId> negatedPhenotypeTerms();
 
+    /**
+     * @return container with genes and genotypes observed in the subject.
+     */
     @JsonIgnore
     GenesAndGenotypes genes();
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisData.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisData.java
@@ -43,16 +43,19 @@ public interface AnalysisData {
     /**
      * @return a non-null sample ID.
      */
+    @JsonGetter
     String sampleId();
 
     /**
      * @return an optional with age or empty optional if age is not available.
      */
+    @JsonGetter
     Optional<Age> age();
 
     /**
      * @return a non-null sex of the subject.
      */
+    @JsonGetter(value = "sex")
     Sex sex();
 
     /**

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataDefault.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataDefault.java
@@ -1,19 +1,97 @@
 package org.monarchinitiative.lirical.core.analysis;
 
-import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
 import org.monarchinitiative.lirical.core.model.Age;
+import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
 import org.monarchinitiative.lirical.core.model.Sex;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Default implementation of {@link AnalysisData}.
  */
-record AnalysisDataDefault(String sampleId,
-                           Age age,
-                           Sex sex,
-                           List<TermId> presentPhenotypeTerms,
-                           List<TermId> negatedPhenotypeTerms,
-                           GenesAndGenotypes genes) implements AnalysisData {
+final class AnalysisDataDefault implements AnalysisData {
+    private final String sampleId;
+    private final Age age;
+    private final Sex sex;
+    private final List<TermId> presentPhenotypeTerms;
+    private final List<TermId> negatedPhenotypeTerms;
+    private final GenesAndGenotypes genes;
+
+    AnalysisDataDefault(String sampleId,
+                        Age age,
+                        Sex sex,
+                        Collection<TermId> presentPhenotypeTerms,
+                        Collection<TermId> negatedPhenotypeTerms,
+                        GenesAndGenotypes genes) {
+        this.sampleId = Objects.requireNonNull(sampleId);
+        this.age = age;
+        this.sex = Objects.requireNonNull(sex);
+        this.presentPhenotypeTerms = List.copyOf(Objects.requireNonNull(presentPhenotypeTerms));
+        this.negatedPhenotypeTerms = List.copyOf(Objects.requireNonNull(negatedPhenotypeTerms));
+        this.genes = Objects.requireNonNull(genes);
+    }
+
+    @Override
+    public String sampleId() {
+        return sampleId;
+    }
+
+    @Override
+    public Optional<Age> age() {
+        return Optional.ofNullable(age);
+    }
+
+    @Override
+    public Sex sex() {
+        return sex;
+    }
+
+    @Override
+    public List<TermId> presentPhenotypeTerms() {
+        return presentPhenotypeTerms;
+    }
+
+    @Override
+    public List<TermId> negatedPhenotypeTerms() {
+        return negatedPhenotypeTerms;
+    }
+
+    @Override
+    public GenesAndGenotypes genes() {
+        return genes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (AnalysisDataDefault) obj;
+        return Objects.equals(this.sampleId, that.sampleId) &&
+                Objects.equals(this.age, that.age) &&
+                Objects.equals(this.sex, that.sex) &&
+                Objects.equals(this.presentPhenotypeTerms, that.presentPhenotypeTerms) &&
+                Objects.equals(this.negatedPhenotypeTerms, that.negatedPhenotypeTerms) &&
+                Objects.equals(this.genes, that.genes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sampleId, age, sex, presentPhenotypeTerms, negatedPhenotypeTerms, genes);
+    }
+
+    @Override
+    public String toString() {
+        return "AnalysisDataDefault[" +
+                "sampleId=" + sampleId + ", " +
+                "age=" + age + ", " +
+                "sex=" + sex + ", " +
+                "presentPhenotypeTerms=" + presentPhenotypeTerms + ", " +
+                "negatedPhenotypeTerms=" + negatedPhenotypeTerms + ", " +
+                "genes=" + genes + ']';
+    }
+
 }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataParser.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisDataParser.java
@@ -5,6 +5,7 @@ import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
 
 import java.io.InputStream;
 
+// REMOVE(v2.0.0)
 @Deprecated(forRemoval = true)
 public interface AnalysisDataParser {
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/LiricalParseException.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/LiricalParseException.java
@@ -5,6 +5,7 @@ import org.monarchinitiative.lirical.core.exception.LiricalException;
 /**
  * An exception thrown when user-provided input is invalid.
  */
+// TODO - move to CLI after removing AnalysisDataParser.
 public class LiricalParseException extends LiricalException {
 
     public LiricalParseException() {

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Default LIRICAL analysis implementation.
+ */
+package org.monarchinitiative.lirical.core.analysis.impl;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/package-info.java
@@ -1,4 +1,11 @@
 /**
- * Classes for coordinating the main Lirical analysis goals.
+ * A high-level representation of LIRICAL analysis.
+ * <p>
+ * The analysis subject is provided as {@link org.monarchinitiative.lirical.core.analysis.AnalysisData}. The analysis
+ * is parameterized by {@link org.monarchinitiative.lirical.core.analysis.AnalysisOptions}.
+ * {@link org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner} executes the analysis. The output
+ * are wrapped into {@link org.monarchinitiative.lirical.core.analysis.AnalysisResults} which reports results
+ * of matching the subject to computational disease models,
+ * one {@link org.monarchinitiative.lirical.core.analysis.TestResult} per disease.
  */
 package org.monarchinitiative.lirical.core.analysis;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/probability/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model of pretest probability of diseases.
+ */
+package org.monarchinitiative.lirical.core.analysis.probability;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/exception/LiricalAnalysisException.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/exception/LiricalAnalysisException.java
@@ -3,7 +3,10 @@ package org.monarchinitiative.lirical.core.exception;
 /**
  * An exception thrown by {@link org.monarchinitiative.lirical.core.analysis.LiricalAnalysisRunner} if the analysis
  * cannot be run.
+ * @deprecated will be moved into {@link org.monarchinitiative.lirical.core.analysis} package.
  */
+// TODO - move to analysis package.
+@Deprecated(forRemoval = true)
 public class LiricalAnalysisException extends LiricalException {
     public LiricalAnalysisException() {
         super();

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/exception/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Top-level exceptions.
+ */
+package org.monarchinitiative.lirical.core.exception;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/io/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/io/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * APIs for reading and annotation of genomic variants.
+ * <p>
+ * LIRICAL needs to read genomic variants, perform functional annotation, and fetch variant frequencies for the variants.
+ * LIRICAL does not care about how this is done, as long as the variants meet
+ * the {@link org.monarchinitiative.lirical.core.model.LiricalVariant} requirements.
+ * <p>
+ * One way to configure the functional annotation is to implement {@link org.monarchinitiative.lirical.core.io.VariantParserFactory}
+ * which can provide a {@link org.monarchinitiative.lirical.core.io.VariantParser} to read variants
+ * from a {@link java.nio.file.Path} given {@link org.monarchinitiative.lirical.core.model.GenomeBuild}
+ * and {@link org.monarchinitiative.lirical.core.model.TranscriptDatabase}. For instance, to read variants
+ * from a VCF file.
+ */
+package org.monarchinitiative.lirical.core.io;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/package-info.java
@@ -1,4 +1,6 @@
-/** Classes related to the calculation of likelihood ratios for phenotypic or genotypic test results.
+/**
+ * Package with logic for calculation of likelihood ratios for phenotypic or genotypic test results.
+ *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
 package org.monarchinitiative.lirical.core.likelihoodratio;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/Age.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/Age.java
@@ -7,46 +7,27 @@ import java.time.Period;
 import java.util.Objects;
 
 /**
- * Convenience class to represent the age of a proband. Note that if (@link #initialized} is false,
- * then we are representing the fact that we do not know the age we will disregard the feature
- * in our calculations. We will represent prenatal age as number of completed gestational weeks and days,
+ * Convenience class to represent the age of a subject.
+ * <p>
+ * We will represent prenatal age as number of completed gestational weeks and days,
  * and {@link #isGestational()} flag will be set.
+ *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
 @JsonSerialize(using = AgeSerializer.class)
 public class Age {
-    // TODO - make the unknown age unambiguous.
-    //  If we use the Age#ageNotKnown() to represent the absence of age, then the AnalysisData#age() should be non-null (Optional?)
-    //  Otherwise, we should allow AnalysisData#age() to be null and drop Age#ageNotKnown().
-    private final boolean isUnknown;
     private final boolean isGestational;
     private final int years;
     private final int months;
     private final int weeks;
     private final int days;
-    /** Used as a constant if we do not have information about the age of a proband. */
-    private final static Age NOT_KNOWN = new Age();
 
     private Age(int years, int months, int weeks, int days) {
         this.years=years;
         this.months=months;
         this.weeks=weeks;
         this.days=days;
-        this.isUnknown = false;
         this.isGestational = weeks != 0;
-    }
-
-    private Age() {
-        this.years=0;
-        this.months=0;
-        this.weeks=0;
-        this.days=0;
-        this.isUnknown = true;
-        this.isGestational = false;
-    }
-
-    public static Age ageNotKnown() {
-        return NOT_KNOWN;
     }
 
     @JsonIgnore
@@ -67,11 +48,6 @@ public class Age {
     @JsonIgnore
     public int getDays() {
         return days;
-    }
-
-    @JsonIgnore
-    public boolean isUnknown() {
-        return isUnknown;
     }
 
     @JsonIgnore
@@ -121,8 +97,7 @@ public class Age {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Age age = (Age) o;
-        return isUnknown == age.isUnknown &&
-                years == age.years &&
+        return years == age.years &&
                 months == age.months &&
                 weeks == age.weeks &&
                 days == age.days;
@@ -130,14 +105,13 @@ public class Age {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isUnknown, years, months, weeks, days);
+        return Objects.hash(years, months, weeks, days);
     }
 
     @Override
     public String toString() {
         return "Age{" +
-                "isUnknown=" + isUnknown +
-                ", years=" + years +
+                "years=" + years +
                 ", months=" + months +
                 ", weeks=" + weeks +
                 ", days=" + days +

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/Age.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/Age.java
@@ -9,8 +9,13 @@ import java.util.Objects;
 /**
  * Convenience class to represent the age of a subject.
  * <p>
- * We will represent prenatal age as number of completed gestational weeks and days,
- * and {@link #isGestational()} flag will be set.
+ * We represent both <em>postnatal</em> and <em>gestational</em> age. Use {@link #isGestational()}
+ * or {@link #isPostnatal()} to tell them apart.
+ * <p>
+ * The postnatal age has {@link #getYears()}, {@link #getMonths()}, and {@link #getDays()} fields set
+ * and {@link #getWeeks()} should be ignored.
+ * <p>
+ * The gestational age uses {@link #getWeeks()} and {@link #getDays()} fields.
  *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
@@ -22,12 +27,12 @@ public class Age {
     private final int weeks;
     private final int days;
 
-    private Age(int years, int months, int weeks, int days) {
-        this.years=years;
-        this.months=months;
-        this.weeks=weeks;
-        this.days=days;
-        this.isGestational = weeks != 0;
+    private Age(int years, int months, int weeks, int days, boolean isGestational) {
+        this.years=requireNonNegativeInt(years, "Years must not be negative");
+        this.months=requireNonNegativeInt(months, "Months must not be negative");
+        this.weeks=requireNonNegativeInt(weeks, "Weeks must not be negative");
+        this.days=requireNonNegativeInt(days, "Days must not be negative");
+        this.isGestational = isGestational;
     }
 
     @JsonIgnore
@@ -60,36 +65,66 @@ public class Age {
         return !isGestational;
     }
 
+    /**
+     * Create a postnatal age to represent {@code y} years of age.
+     *
+     * @param y a non-negative number of years.
+     */
     public static Age ageInYears(int y) {
         return of(y,0,0);
     }
 
+    /**
+     * Create a postnatal age to represent {@code m} months of age.
+     *
+     * @param m a non-negative number of months.
+     */
     public static Age ageInMonths(int m) {
         return of(0,m,0);
     }
 
+    /**
+     * Create a postnatal age to represent {@code d} days of age.
+     *
+     * @param d a non-negative number of days.
+     */
     public static Age ageInDays(int d) {
         return of(0,0,d);
     }
 
     /**
      * @param period representing <em>postnatal</em> (<em>not</em> gestational) age.
-     * @return age object
      */
     public static Age parse(Period period) {
         Period normalized = period.normalized();
         return of(normalized.getYears(), normalized.getMonths(), normalized.getDays());
     }
 
+    /**
+     * Create a gestational age to represent {@code weeks} and {@code days}.
+     * <p>
+     * {@code weeks} should generally be not be greater than 42, and it must not be negative.
+     * {@code days} must be in range {@code [0,6]}.
+     *
+     * @param weeks a non-negative number of completed gestational weeks.
+     * @param days the number of completed gestational days.
+     */
     public static Age gestationalAge(int weeks, int days) {
-        return new Age(0, 0, weeks, days);
+        return new Age(0, 0, weeks, days, true);
     }
 
     /**
      * Create a <em>postnatal</em> age from given inputs.
      */
     public static Age of(int years, int months, int days) {
-        return new Age(years, months, 0, days);
+        return new Age(years, months, 0, days, false);
+    }
+
+    private static int requireNonNegativeInt(int value, String msg) {
+        if (value < 0) {
+            throw new IllegalArgumentException(msg);
+        } else
+            return value;
     }
 
     @Override

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/HpoCase.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/HpoCase.java
@@ -106,7 +106,7 @@ public final class HpoCase {
             this.observedAbnormalities = List.copyOf(Objects.requireNonNull(abnormalPhenotypes));
             excludedAbnormalities=List.of(); // default empty list
             sex=Sex.UNKNOWN;
-            age=Age.ageNotKnown();
+            age=null;
         }
 
         public Builder excluded(List<TermId> excludedPhenotypes) {

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/HpoCase.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/HpoCase.java
@@ -42,7 +42,7 @@ public final class HpoCase {
         this.excludedAbnormalities = Objects.requireNonNull(excludedTerms);
         this.results = Objects.requireNonNull(results);
         this.sex = Objects.requireNonNull(sex);
-        this.age = Objects.requireNonNull(age);
+        this.age = age;
     }
 
     public String sampleId() {

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package with data models.
+ */
+package org.monarchinitiative.lirical.core.model;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core functionality of the LIRICAL algorithm.
+ */
+package org.monarchinitiative.lirical.core;

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/package-info.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/service/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package with services used across LIRICAL.
+ */
+package org.monarchinitiative.lirical.core.service;

--- a/lirical-core/src/test/java/org/monarchinitiative/lirical/core/model/HpoCaseTest.java
+++ b/lirical-core/src/test/java/org/monarchinitiative/lirical/core/model/HpoCaseTest.java
@@ -9,8 +9,7 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -74,7 +73,7 @@ public class HpoCaseTest {
     @Test
     public void testAge() {
         // we did not specify the age, so it should return not known
-        assertEquals(Age.ageNotKnown(),hpocase.getAge());
+        assertNull(hpocase.getAge());
     }
 
     @Test

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/package-info.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/package-info.java
@@ -1,3 +1,5 @@
-/** Parsers for LIRICAL.
+/**
+ * Parsers for LIRICAL.
+ *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>*/
 package org.monarchinitiative.lirical.io;


### PR DESCRIPTION
Previously we could have `Age` that was unknown. However, this is better modeled by making the `Age` optional and using `null` to represent its absence, since `null` conveys the same meaning.

The PR simplifies the code that uses `Age` and adds bounds checks on values to prevent using negative years, months, ... .