### PR TITLE
Remove misplaced dependency from `lirical-configuration` POM

### DIFF
--- a/lirical-configuration/pom.xml
+++ b/lirical-configuration/pom.xml
@@ -34,10 +34,6 @@
             <groupId>org.monarchinitiative.phenol</groupId>
             <artifactId>phenol-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
`logback-classic` should not have never been in `lirical-configuration` 😱