### PR TITLE
Use `en_US` to run tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.3</version>
+                    <configuration>
+                        <argLine>-Duser.language=en -Duser.region=US</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Use a defined locale to run tests.

Fix #655 