### PR TITLE
Allow focusing the prioritization on a subset of diseases

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -80,6 +80,10 @@ The configuration options tweak the analysis.
   The JSON report will include *all* diseases all the time.
 * ``--transcript-db``: transcript database (default: ``RefSeq``), see :ref:`rsttx-dbs` for more info.
 * ``--use-orphanet``: use `Orphanet <https://www.orpha.net/consor/cgi-bin/index.php>`_ annotations (default: ``false``).
+* ``--target-diseases``: limit the analysis to the provided disease IDs.
+  Expecting a comma-separated list of diseaes IDs, such as `OMIM:614102,OMIM:619340`.
+  The ``--use-orphanet`` option is ignored if at least one disease ID is provided.
+  All diseases are analyzed by default.
 * ``--strict``: use strict penalties if the genotype does not match the disease model
   in terms of number of called pathogenic alleles (default: ``false``).
 * ``--pathogenicity-threshold``: Variants with greater pathogenicity score is considered deleterious (default: ``0.8``).

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptionsDefault.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptionsDefault.java
@@ -4,13 +4,16 @@ import org.monarchinitiative.lirical.core.analysis.probability.PretestDiseasePro
 import org.monarchinitiative.lirical.core.model.GenomeBuild;
 import org.monarchinitiative.lirical.core.model.TranscriptDatabase;
 import org.monarchinitiative.phenol.annotations.io.hpo.DiseaseDatabase;
+import org.monarchinitiative.phenol.ontology.data.TermId;
 
+import java.util.Collection;
 import java.util.Set;
 
 record AnalysisOptionsDefault(
         GenomeBuild genomeBuild,
         TranscriptDatabase transcriptDatabase,
         Set<DiseaseDatabase> diseaseDatabases,
+        Collection<TermId> targetDiseases,
         float variantDeleteriousnessThreshold,
         double defaultVariantBackgroundFrequency,
         boolean useStrictPenalties,


### PR DESCRIPTION
Allow scoping the analysis on a subset of diseases with the `--target-diseases` option (CLI) or `AnalysisOptions.Builder.setTargetDiseases` (API).