### PR TITLE
Allow running in phenotype only mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ hs_err_pid*
 target/
 *.iml
 *.log
-data/
+/data
 results/
 dependency-reduced-pom.xml
 .settings

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -11,7 +11,7 @@ or NGS gene-panel sequencing.
 On typical computers, LIRICAL will run from about 15 to 60 seconds in phenotype-only mode,
 ~5 minutes with a typical exome file, or longer if a whole-genome file is used as input.
 
-To get help, run LIRICAL with a command or with the option "-h"::
+To get help, run LIRICAL with a command or with the option ``-h``::
 
   lirical --help
   LIkelihood Ratio Interpretation of Clinical AbnormaLities
@@ -157,7 +157,8 @@ The ``prioritize`` command takes the following options:
   that correspond to the phenotype terms observed in the proband.
 * ``-n | --negated-phenotypes``: a comma-separated IDs of HPO IDs
   that correspond to the phenotype terms negated/excluded in the proband.
-* ``--assembly`` genome build, choose from `hg19` or `hg38`, must be provided if ``--vcf`` is used (default: ``hg38``).
+* ``--assembly`` genome build, choose from `hg19` or `hg38`, must be provided if ``--vcf`` is used.
+  If unset, the analysis will be run in phenotype-only mode.
 * ``--vcf``: path to VCF file with exome/genome sequencing results. The file can be compressed.
 * ``--sample-id``: proband's identifier, must be provided if running with a multi-sample VCF file (default: `subject`).
 * ``--age``: proband's age as an ISO8601 duration.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -157,8 +157,9 @@ The ``prioritize`` command takes the following options:
   that correspond to the phenotype terms observed in the proband.
 * ``-n | --negated-phenotypes``: a comma-separated IDs of HPO IDs
   that correspond to the phenotype terms negated/excluded in the proband.
-* ``--assembly`` genome build, choose from `hg19` or `hg38`, must be provided if ``--vcf`` is used.
-  If unset, the analysis will be run in phenotype-only mode.
+* ``--assembly`` genome build, choose from `hg19` or `hg38`.
+  The assembly must be provided if ``--vcf`` is used. If both ``--assembly`` and ``--vcf`` are unset,
+  the analysis will be run in phenotype-only mode.
 * ``--vcf``: path to VCF file with exome/genome sequencing results. The file can be compressed.
 * ``--sample-id``: proband's identifier, must be provided if running with a multi-sample VCF file (default: `subject`).
 * ``--age``: proband's age as an ISO8601 duration.
@@ -242,7 +243,8 @@ Save the file above as ``pfeiffer.json``.
 **Running LIRICAL with clinical data**
 
 
-LIRICAL will perform phenotype-only analysis if the ``phenopacket`` command incantation does not contain a ``--vcf`` option.
+LIRICAL will perform phenotype-only analysis if the ``phenopacket`` command incantation does not contain
+the ``--assembly`` and ``--vcf`` options.
 In this case, the only required argument is the phenopacket::
 
   lirical phenopacket -p pfeiffer.json
@@ -250,10 +252,15 @@ In this case, the only required argument is the phenopacket::
 
 **Running LIRICAL with a VCF file**
 
-Alternatively, LIRICAL can include the VCF file if the path is provided using ``--vcf`` option.
-Note, we must also provide ``--assembly`` and ``-e19`` (or ``-e38``) options to indicate the genome assembly and path to Exomiser variant database::
+Alternatively, LIRICAL can use a VCF file if the path is provided using ``--vcf`` option.
+Note, the ``--assembly`` and ``-ed19`` (or ``-ed38``) options to indicate the genome assembly
+and path to Exomiser data directory must also be provided::
 
-  lirical phenopacket -p pfeiffer.json --vcf path/to/pfeiffer.vcf.gz --assembly hg19 -e19 /path/to/exomiser/2302_hg19_variants.mv.db
+  lirical phenopacket \
+    --assembly hg19 \
+    --vcf path/to/pfeiffer.vcf.gz \
+    -ed19 /path/to/exomiser/datadir \
+    -p pfeiffer.json
 
 
 ``yaml`` - running LIRICAL with a YAML file
@@ -271,7 +278,7 @@ This will run the phenotype-only analysis of the *Patient 4*.
 To run the genotype-aware analysis, modify the YAML file such that the ``vcf`` field points to the location
 of the VCF file on your file system. Then, the analysis is run as::
 
- lirical yaml -y example.yml --assembly hg19 -e19 /path/to/exomiser/2302_hg19_variants.mv.db
+ lirical yaml -y example.yml --assembly hg19 -ed19 /path/to/exomiser/datadir
 
 
 Choosing between YAML and Phenopacket input formats

--- a/docs/yaml.rst
+++ b/docs/yaml.rst
@@ -33,7 +33,8 @@ indicate the start of the contents of the file.
 5. ``sex`` sex of the individual, either ``MALE`` or ``FEMALE``.
 6. ``vcf`` is the path to the file we want to analyze.
    Note that the VCF file must contain the sample corresponding to ``sampleId`` and
-   the CLI must include ``--assembly`` and ``-e19 | -e38`` options to run with a VCF file.
+   the CLI must include ``--assembly`` and ``-ed19 | -ed38`` options to leverage the VCF file
+to run a genotype-aware analysis.
 
 You can use the example file as a starting point for your own configuration file.
 An example YAML file can also be found

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -3,6 +3,7 @@ package org.monarchinitiative.lirical.cli.cmd;
 import org.monarchinitiative.lirical.core.Lirical;
 import org.monarchinitiative.lirical.core.analysis.*;
 import org.monarchinitiative.lirical.core.exception.LiricalException;
+import org.monarchinitiative.lirical.core.io.VariantParserFactory;
 import org.monarchinitiative.lirical.core.model.FilteringStats;
 import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
 import org.monarchinitiative.lirical.core.model.GenomeBuild;
@@ -45,16 +46,13 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
         try {
             Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
             if (genomeBuild.isPresent()) {
-                LOGGER.debug("Using genome build {}", genomeBuild);
+                LOGGER.debug("Using genome build {}", genomeBuild.get());
+
+                LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
             } else {
-                LOGGER.debug("Genome build is unset, LIRICAL will be run in phenotype only mode");
+                LOGGER.debug("Running a phenotype-only analysis");
             }
-
-            LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
             TranscriptDatabase transcriptDb = runConfiguration.transcriptDb;
-
-            LOGGER.info("Parsing the analysis inputs");
-            SanitationInputs inputs = procureSanitationInputs();
 
             // 1 - bootstrap the app
             LOGGER.info("Bootstrapping LIRICAL");
@@ -62,6 +60,9 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
             LOGGER.info("Configured LIRICAL {}", lirical.version()
                     .map("v%s"::formatted)
                     .orElse(UNKNOWN_VERSION_PLACEHOLDER));
+
+            LOGGER.info("Parsing the analysis inputs");
+            SanitationInputs inputs = procureSanitationInputs();
 
             // 2 - sanitize inputs
             InputSanitizerFactory sanitizerFactory = new InputSanitizerFactory(lirical.phenotypeService().hpo());
@@ -98,10 +99,19 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
             }
 
             // 3 - prepare analysis data
-            AnalysisData analysisData = prepareAnalysisData(lirical, genomeBuild.orElse(null), transcriptDb, result.sanitizedInputs());
+            AnalysisData analysisData = prepareAnalysisData(
+                    lirical.variantParserFactory(),
+                    genomeBuild.orElse(null),
+                    transcriptDb,
+                    result.sanitizedInputs()
+        );
 
             // 4 - run the analysis
-            AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild.orElse(null), transcriptDb);
+            AnalysisOptions analysisOptions = prepareAnalysisOptions(
+                    lirical,
+                    genomeBuild.orElse(null),
+                    transcriptDb
+            );
             LOGGER.info("Starting the analysis");
             AnalysisResults results;
             try (LiricalAnalysisRunner analysisRunner = lirical.analysisRunner()) {
@@ -146,30 +156,32 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
 
     protected abstract SanitationInputs procureSanitationInputs() throws LiricalParseException;
 
+    /**
+     * Read the analysis data for a sample.
+     *
+     * @param genomeBuild build or {@code null} if we're performing a phenotype-only run.
+     * @throws LiricalParseException if reading
+     */
     private static AnalysisData prepareAnalysisData(
-        Lirical lirical,
-        GenomeBuild genomeBuild,
-        TranscriptDatabase transcriptDb,
-        SanitizedInputs inputs
+            VariantParserFactory variantParserFactory,
+            GenomeBuild genomeBuild,
+            TranscriptDatabase transcriptDb,
+            SanitizedInputs inputs
     ) throws LiricalParseException {
         // Read VCF file if present.
         String sampleId;
         GenesAndGenotypes genes;
-        if (genomeBuild == null) {
-            if (inputs.sampleId() == null) {
-                // Use placeholder, because the user did not provide sample ID,
-                // and we're running phenotype-only analysis.
-                sampleId = "subject";
-            } else {
-                sampleId = inputs.sampleId();
-            }
+        if (genomeBuild == null || inputs.vcf() == null) {
+            // Use placeholder, because the user did not provide sample ID,
+            // and we're running phenotype-only analysis.
+            sampleId = "subject";
             genes = GenesAndGenotypes.empty();
         } else {
             SampleIdAndGenesAndGenotypes sampleAndGenotypes = readVariantsFromVcfFile(inputs.sampleId(),
                     inputs.vcf(),
                     genomeBuild,
                     transcriptDb,
-                    lirical.variantParserFactory());
+                    variantParserFactory);
             sampleId = sampleAndGenotypes.sampleId();
             genes = sampleAndGenotypes.genesAndGenotypes();
         }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -43,8 +43,12 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
         }
 
         try {
-            GenomeBuild genomeBuild = parseGenomeBuild(getGenomeBuild());
-            LOGGER.debug("Using genome build {}", genomeBuild);
+            Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
+            if (genomeBuild.isPresent()) {
+                LOGGER.debug("Using genome build {}", genomeBuild);
+            } else {
+                LOGGER.debug("Genome build is unset, LIRICAL will be run in phenotype only mode");
+            }
 
             LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
             TranscriptDatabase transcriptDb = runConfiguration.transcriptDb;
@@ -54,7 +58,7 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
 
             // 1 - bootstrap the app
             LOGGER.info("Bootstrapping LIRICAL");
-            Lirical lirical = bootstrapLirical(genomeBuild);
+            Lirical lirical = bootstrapLirical(genomeBuild.orElse(null));
             LOGGER.info("Configured LIRICAL {}", lirical.version()
                     .map("v%s"::formatted)
                     .orElse(UNKNOWN_VERSION_PLACEHOLDER));
@@ -94,10 +98,10 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
             }
 
             // 3 - prepare analysis data
-            AnalysisData analysisData = prepareAnalysisData(lirical, genomeBuild, transcriptDb, result.sanitizedInputs());
+            AnalysisData analysisData = prepareAnalysisData(lirical, genomeBuild.orElse(null), transcriptDb, result.sanitizedInputs());
 
             // 4 - run the analysis
-            AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild, transcriptDb);
+            AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild.orElse(null), transcriptDb);
             LOGGER.info("Starting the analysis");
             AnalysisResults results;
             try (LiricalAnalysisRunner analysisRunner = lirical.analysisRunner()) {
@@ -143,18 +147,22 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
     protected abstract SanitationInputs procureSanitationInputs() throws LiricalParseException;
 
     private static AnalysisData prepareAnalysisData(
-            Lirical lirical,
-            GenomeBuild genomeBuild,
-            TranscriptDatabase transcriptDb,
-            SanitizedInputs inputs
+        Lirical lirical,
+        GenomeBuild genomeBuild,
+        TranscriptDatabase transcriptDb,
+        SanitizedInputs inputs
     ) throws LiricalParseException {
         // Read VCF file if present.
         String sampleId;
         GenesAndGenotypes genes;
-        if (inputs.vcf() == null) {
-            // Use placeholder, because the user did not provide sample ID,
-            // and we're running phenotype-only analysis.
-            sampleId = "subject";
+        if (genomeBuild == null) {
+            if (inputs.sampleId() == null) {
+                // Use placeholder, because the user did not provide sample ID,
+                // and we're running phenotype-only analysis.
+                sampleId = "subject";
+            } else {
+                sampleId = inputs.sampleId();
+            }
             genes = GenesAndGenotypes.empty();
         } else {
             SampleIdAndGenesAndGenotypes sampleAndGenotypes = readVariantsFromVcfFile(inputs.sampleId(),

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/AbstractPrioritizeCommand.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -193,5 +194,20 @@ abstract class AbstractPrioritizeCommand extends OutputCommand {
                 inputs.presentHpoTerms(),
                 inputs.excludedHpoTerms(),
                 genes);
+    }
+
+    protected static String checkVcfAndAssembly(Path vcfPath, String genomeBuild) {
+        if (vcfPath == null ^ genomeBuild == null) {
+            StringBuilder builder = new StringBuilder();
+            if (vcfPath == null)
+                builder.append("The --assembly is set but --vcf is not specified.");
+            else
+                builder.append("The --vcf is set but --assembly is not specified.");
+            builder.append(" ");
+            builder.append("Proceed either with genotype-aware analysis with both --vcf and --assembly options, or run a phenotype-only analysis without the --vcf and --assembly options.");
+            return builder.toString();
+        } else {
+            return null;
+        }
     }
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BenchmarkCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BenchmarkCommand.java
@@ -22,10 +22,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 
@@ -57,13 +62,23 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
             description = "Where to write the benchmark results CSV file. The CSV is compressed if the path has the '.gz' suffix")
     protected Path outputPath;
 
+    // TODO: remove in 3.0.0
+    @Deprecated(
+            since = "2.1.1",
+            forRemoval = true
+    )
     @CommandLine.Option(names = {"--phenotype-only"},
             description = "Run the benchmark with phenotypes only (default: ${DEFAULT-VALUE})")
     protected boolean phenotypeOnly = false;
 
-    @CommandLine.Option(names = {"--assembly"},
+    @CommandLine.Option(
+            names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: unset).")
+            description = {
+                    "Genome build.",
+                    "Leave unset if the benchmark should be run in phenotype-only mode.",
+                    "Default: ${DEFAULT-VALUE}"
+            })
     protected String genomeBuild = null;
 
     @Override
@@ -76,6 +91,14 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
             LOGGER.error("Errors:");
             for (String error : errors)
                 LOGGER.error("  {}", error);
+            return 1;
+        }
+
+        if (phenotypeOnly && genomeBuild != null) {
+            LOGGER.error(
+                    "`--phenotype-only` option has been deprecated. "
+                    + "Do not use the `--assembly` option to run in a phenotype-only mode"
+            );
             return 1;
         }
 
@@ -121,7 +144,13 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
                     LOGGER.info("Starting the analysis of [{}/{}] {}", i + 1, sanitationResults.size(),
                             result.path().toFile().getName());
                     // 3 - prepare benchmark data per phenopacket
-                    BenchmarkData benchmarkData = prepareBenchmarkData(lirical, genomeBuild.orElse(null), transcriptDb, backgroundVariants, result);
+                    BenchmarkData benchmarkData = prepareBenchmarkData(
+                            lirical,
+                            genomeBuild.orElse(null),
+                            transcriptDb,
+                            backgroundVariants,
+                            result
+                    );
 
                     // 4 - run the analysis.
                     AnalysisResults results = analysisRunner.run(benchmarkData.analysisData(), analysisOptions);
@@ -191,16 +220,19 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
         }
     }
 
-    private BenchmarkData prepareBenchmarkData(Lirical lirical,
-                                               GenomeBuild genomeBuild,
-                                               TranscriptDatabase transcriptDatabase,
-                                               List<LiricalVariant> backgroundVariants,
-                                               DataAndSanitationResultsAndPath resultsAndPath) {
+    private BenchmarkData prepareBenchmarkData(
+            Lirical lirical,
+            GenomeBuild genomeBuild,
+            TranscriptDatabase transcriptDatabase,
+            List<LiricalVariant> backgroundVariants,
+            DataAndSanitationResultsAndPath resultsAndPath
+    ) {
         GenesAndGenotypes genes;
-        if (phenotypeOnly) {
+        if (genomeBuild == null) {
+            // Phenotype-only mode.
             // We omit the VCF even if provided.
             if (!backgroundVariants.isEmpty())
-                LOGGER.warn("The provided VCF file will not be used in `--phenotype-only` mode");
+                LOGGER.warn("The provided VCF file is ignored in phenotype-only benchmark");
             genes = GenesAndGenotypes.empty();
         } else {
             if (backgroundVariants.isEmpty()) // None or empty VCF file.

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BenchmarkCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/BenchmarkCommand.java
@@ -63,8 +63,8 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: ${DEFAULT-VALUE}).")
-    protected String genomeBuild = "hg38";
+            description = "Genome build (default: unset).")
+    protected String genomeBuild = null;
 
     @Override
     public Integer execute() {
@@ -80,15 +80,15 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
         }
 
         try {
-            GenomeBuild genomeBuild = parseGenomeBuild(getGenomeBuild());
+            Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
             TranscriptDatabase transcriptDb = runConfiguration.transcriptDb;
 
             // 1 - bootstrap LIRICAL.
-            Lirical lirical = bootstrapLirical(genomeBuild);
+            Lirical lirical = bootstrapLirical(genomeBuild.orElse(null));
 
             // 2 - prepare the simulation data shared by all phenopackets.
-            AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild, transcriptDb);
-            List<LiricalVariant> backgroundVariants = readBackgroundVariants(lirical, genomeBuild, transcriptDb);
+            AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild.orElse(null), transcriptDb);
+            List<LiricalVariant> backgroundVariants = readBackgroundVariants(lirical, genomeBuild.orElse(null), transcriptDb);
 
             List<DataAndSanitationResultsAndPath> sanitationResults = sanitizePhenopackets(phenopacketPaths,
                     lirical.phenotypeService().hpo());
@@ -121,7 +121,7 @@ public class BenchmarkCommand extends LiricalConfigurationCommand {
                     LOGGER.info("Starting the analysis of [{}/{}] {}", i + 1, sanitationResults.size(),
                             result.path().toFile().getName());
                     // 3 - prepare benchmark data per phenopacket
-                    BenchmarkData benchmarkData = prepareBenchmarkData(lirical, genomeBuild, transcriptDb, backgroundVariants, result);
+                    BenchmarkData benchmarkData = prepareBenchmarkData(lirical, genomeBuild.orElse(null), transcriptDb, backgroundVariants, result);
 
                     // 4 - run the analysis.
                     AnalysisResults results = analysisRunner.run(benchmarkData.analysisData(), analysisOptions);

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -85,7 +85,9 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                 description = {
                         "The number of workers/threads to use.",
                         "The value must be a positive integer.",
-                        "Default: ${DEFAULT-VALUE}"})
+                        "Default: ${DEFAULT-VALUE}"
+                }
+        )
         public int parallelism = 1;
     }
 
@@ -180,12 +182,11 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
 
         LOGGER.debug("Analysis input validation policy: {}", runConfiguration.validationPolicy.name());
 
-        Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
-        if (genomeBuild.isPresent()) {
-            // Check Exomiser resources match the genome build.
-            switch (genomeBuild.get()) {
+        GenomeBuild.parse(getGenomeBuild()).ifPresent(genomeBuild -> {
+            // Check if the Exomiser resources match the genome build.
+            switch (genomeBuild) {
                 case HG19 -> {
-                    if (!exomiserResourcesAppearUsable(
+                    if (exomiserResourcesAppearMisconfigured(
                             dataSection.exomiserHg19DataDirectory,
                             dataSection.exomiserHg19Database,
                             dataSection.exomiserHg19ClinVarDatabase)
@@ -194,7 +195,7 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                     }
                 }
                 case HG38 -> {
-                    if (!exomiserResourcesAppearUsable(
+                    if (exomiserResourcesAppearMisconfigured(
                             dataSection.exomiserHg38DataDirectory,
                             dataSection.exomiserHg38Database,
                             dataSection.exomiserHg38ClinVarDatabase)
@@ -203,7 +204,7 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                     }
                 }
             }
-        }
+        });
 
         if (dataSection.parallelism <= 0) {
             String msg = "Parallelism must be a positive integer but was %d".formatted(dataSection.parallelism);
@@ -224,17 +225,15 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
     }
 
     /**
-     * Build {@link Lirical} for a {@link GenomeBuild} based on {@link DataSection}
-     * and {@link RunConfiguration} sections, or in phenotype-only mode if {@code genomeBuild} is {@code null}.
+     * Build {@link Lirical} for a {@link GenomeBuild} based on {@link DataSection} and {@link RunConfiguration} sections.
+     *
+     * @param genomeBuild the target build or {@code null} if LIRICAL should be configured in phenotype-only mode.
      */
     protected Lirical bootstrapLirical(GenomeBuild genomeBuild) throws LiricalDataException {
         LiricalBuilder builder = LiricalBuilder.builder(dataSection.liricalDataDirectory);
 
-        if (genomeBuild == null)
-            genomeBuild = inferGenomeBuildFromExomiser();
-
         if (genomeBuild != null) {
-            // Deal with Exomiser resources.
+            // Deal with the Exomiser resources.
             ExomiserResources resources = switch (genomeBuild) {
                 case HG19 -> loadExomiserResources(
                         GenomeBuild.HG19,
@@ -250,9 +249,16 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                 );
             };
             builder.exomiserResources(genomeBuild, resources);
+        }
 
-            // Background variant frequencies
-            if (dataSection.backgroundFrequencyFile != null) {
+        // Background variant frequencies
+        if (dataSection.backgroundFrequencyFile != null) {
+            if (genomeBuild == null) {
+                LOGGER.warn(
+                        "Ignoring custom variant background frequency file at {} because genome build is unset",
+                        dataSection.backgroundFrequencyFile.toAbsolutePath()
+                );
+            } else {
                 LOGGER.debug("Using custom deleterious variant background frequency file at {} for {}",
                         dataSection.backgroundFrequencyFile.toAbsolutePath(),
                         genomeBuild);
@@ -267,34 +273,12 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
                 .build();
     }
 
-    private GenomeBuild inferGenomeBuildFromExomiser() {
-        boolean couldProceedWithHg19 = exomiserResourcesAppearUsable(
-                dataSection.exomiserHg19DataDirectory,
-                dataSection.exomiserHg19Database,
-                dataSection.exomiserHg19ClinVarDatabase);
-        boolean couldProceedWithHg38 = exomiserResourcesAppearUsable(
-                dataSection.exomiserHg38DataDirectory,
-                dataSection.exomiserHg38Database,
-                dataSection.exomiserHg38ClinVarDatabase);
-
-        if (couldProceedWithHg38) {
-            //noinspection LoggingSimilarMessage
-            LOGGER.info("Genome build was inferred to {} based on provided Exomiser data resources", GenomeBuild.HG38);
-            return GenomeBuild.HG38; // Use hg38 even if both hg19 and hg38 are set.
-        } else if (couldProceedWithHg19) {
-            LOGGER.info("Genome build was inferred to {} based on provided Exomiser data resources", GenomeBuild.HG19);
-            return GenomeBuild.HG19;
-        } else {
-            return null;
-        }
-    }
-
-    private static boolean exomiserResourcesAppearUsable(
+    private static boolean exomiserResourcesAppearMisconfigured(
             Path exomiserDataDirectory,
             Path exomiserAlleleDatabasePath,
             Path exomiserClinVarDatabasePath
     ) {
-        return exomiserDataDirectory != null || (exomiserAlleleDatabasePath != null && exomiserClinVarDatabasePath != null);
+        return exomiserDataDirectory == null && (exomiserAlleleDatabasePath == null || exomiserClinVarDatabasePath == null);
     }
 
     /**
@@ -308,10 +292,10 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
      * @throws LiricalDataException if one or both database paths are <code>null</code> or do not point to readable file.
      */
     private static ExomiserResources loadExomiserResources(
-        GenomeBuild genomeBuild,
-        Path exomiserDataDirectory,
-        Path exomiserAlleleDatabasePath,
-        Path exomiserClinVarDatabasePath
+            GenomeBuild genomeBuild,
+            Path exomiserDataDirectory,
+            Path exomiserAlleleDatabasePath,
+            Path exomiserClinVarDatabasePath
     ) throws LiricalDataException {
         // At the end of the function, we need to possess path to allele DB and ClinVar DB files.
         //
@@ -407,10 +391,15 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
 
     protected abstract String getGenomeBuild();
 
+    /**
+     * Prepare the options for parametrizing the analysis.
+     *
+     * @param genomeBuild a build or {@code null} if running in phenotype-only mode.
+     */
     protected AnalysisOptions prepareAnalysisOptions(
-        Lirical lirical,
-        GenomeBuild genomeBuild,
-        TranscriptDatabase transcriptDb
+            Lirical lirical,
+            GenomeBuild genomeBuild,
+            TranscriptDatabase transcriptDb
     ) {
         AnalysisOptions.Builder builder = AnalysisOptions.builder();
 
@@ -593,19 +582,18 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
     }
 
     protected static void reportElapsedTime(long startTime, long stopTime) {
-        int elapsedTime = (int)((stopTime - startTime)*(1.0)/1000);
+        int elapsedTime = (int) ((stopTime - startTime) * (1.0) / 1000);
         if (elapsedTime > 3599) {
             int elapsedSeconds = elapsedTime % 60;
-            int elapsedMinutes = (elapsedTime/60) % 60;
-            int elapsedHours = elapsedTime/3600;
-            LOGGER.info(String.format("Elapsed time %d:%2d%2d",elapsedHours,elapsedMinutes,elapsedSeconds));
-        }
-        else if (elapsedTime>59) {
+            int elapsedMinutes = (elapsedTime / 60) % 60;
+            int elapsedHours = elapsedTime / 3600;
+            LOGGER.info(String.format("Elapsed time %d:%2d%2d", elapsedHours, elapsedMinutes, elapsedSeconds));
+        } else if (elapsedTime > 59) {
             int elapsedSeconds = elapsedTime % 60;
-            int elapsedMinutes = (elapsedTime/60) % 60;
-            LOGGER.info(String.format("Elapsed time %d min, %d sec",elapsedMinutes,elapsedSeconds));
+            int elapsedMinutes = (elapsedTime / 60) % 60;
+            LOGGER.info(String.format("Elapsed time %d min, %d sec", elapsedMinutes, elapsedSeconds));
         } else {
-            LOGGER.info("Elapsed time " + (stopTime - startTime) * (1.0) / 1000 + " seconds.");
+            LOGGER.info("Elapsed time {} seconds", (stopTime - startTime) * (1.0) / 1000);
         }
     }
 

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/LiricalConfigurationCommand.java
@@ -181,23 +181,23 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
         LOGGER.debug("Analysis input validation policy: {}", runConfiguration.validationPolicy.name());
 
         Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
-        if (genomeBuild.isEmpty()) {
-            // We must have genome build!
-            String msg = "Genome build must be set";
-            errors.add(msg);
-        } else {
+        if (genomeBuild.isPresent()) {
             // Check Exomiser resources match the genome build.
             switch (genomeBuild.get()) {
                 case HG19 -> {
-                    if (dataSection.exomiserHg19DataDirectory == null
-                            && (dataSection.exomiserHg19Database == null || dataSection.exomiserHg19ClinVarDatabase == null)
+                    if (!exomiserResourcesAppearUsable(
+                            dataSection.exomiserHg19DataDirectory,
+                            dataSection.exomiserHg19Database,
+                            dataSection.exomiserHg19ClinVarDatabase)
                     ) {
                         errors.add("Genome build set to HG19 but Exomiser resources are unset");
                     }
                 }
                 case HG38 -> {
-                    if (dataSection.exomiserHg38DataDirectory == null
-                            && (dataSection.exomiserHg38Database == null || dataSection.exomiserHg38ClinVarDatabase == null)
+                    if (!exomiserResourcesAppearUsable(
+                            dataSection.exomiserHg38DataDirectory,
+                            dataSection.exomiserHg38Database,
+                            dataSection.exomiserHg38ClinVarDatabase)
                     ) {
                         errors.add("Genome build set to HG38 but Exomiser resources are unset");
                     }
@@ -224,41 +224,77 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
     }
 
     /**
-     * Build {@link Lirical} for a {@link GenomeBuild} based on {@link DataSection} and {@link RunConfiguration} sections.
+     * Build {@link Lirical} for a {@link GenomeBuild} based on {@link DataSection}
+     * and {@link RunConfiguration} sections, or in phenotype-only mode if {@code genomeBuild} is {@code null}.
      */
     protected Lirical bootstrapLirical(GenomeBuild genomeBuild) throws LiricalDataException {
         LiricalBuilder builder = LiricalBuilder.builder(dataSection.liricalDataDirectory);
 
-        // Deal with Exomiser resources.
-        ExomiserResources resources = switch (genomeBuild) {
-            case HG19 -> loadExomiserResources(
-                    GenomeBuild.HG19,
-                    dataSection.exomiserHg19DataDirectory,
-                    dataSection.exomiserHg19Database,
-                    dataSection.exomiserHg19ClinVarDatabase
-            );
-            case HG38 -> loadExomiserResources(
-                    GenomeBuild.HG38,
-                    dataSection.exomiserHg38DataDirectory,
-                    dataSection.exomiserHg38Database,
-                    dataSection.exomiserHg38ClinVarDatabase
-            );
-        };
-        builder.exomiserResources(genomeBuild, resources);
+        if (genomeBuild == null)
+            genomeBuild = inferGenomeBuildFromExomiser();
 
-        // Background variant frequencies
-        if (dataSection.backgroundFrequencyFile != null) {
-            LOGGER.debug("Using custom deleterious variant background frequency file at {} for {}",
-                    dataSection.backgroundFrequencyFile.toAbsolutePath(),
-                    genomeBuild);
-            Map<GenomeBuild, Path> backgroundFrequencies = Map.of(genomeBuild, dataSection.backgroundFrequencyFile);
-            CustomBackgroundVariantFrequencyServiceFactory backgroundFreqFactory = CustomBackgroundVariantFrequencyServiceFactory.of(backgroundFrequencies);
-            builder.backgroundVariantFrequencyServiceFactory(backgroundFreqFactory);
+        if (genomeBuild != null) {
+            // Deal with Exomiser resources.
+            ExomiserResources resources = switch (genomeBuild) {
+                case HG19 -> loadExomiserResources(
+                        GenomeBuild.HG19,
+                        dataSection.exomiserHg19DataDirectory,
+                        dataSection.exomiserHg19Database,
+                        dataSection.exomiserHg19ClinVarDatabase
+                );
+                case HG38 -> loadExomiserResources(
+                        GenomeBuild.HG38,
+                        dataSection.exomiserHg38DataDirectory,
+                        dataSection.exomiserHg38Database,
+                        dataSection.exomiserHg38ClinVarDatabase
+                );
+            };
+            builder.exomiserResources(genomeBuild, resources);
+
+            // Background variant frequencies
+            if (dataSection.backgroundFrequencyFile != null) {
+                LOGGER.debug("Using custom deleterious variant background frequency file at {} for {}",
+                        dataSection.backgroundFrequencyFile.toAbsolutePath(),
+                        genomeBuild);
+                Map<GenomeBuild, Path> backgroundFrequencies = Map.of(genomeBuild, dataSection.backgroundFrequencyFile);
+                CustomBackgroundVariantFrequencyServiceFactory backgroundFreqFactory = CustomBackgroundVariantFrequencyServiceFactory.of(backgroundFrequencies);
+                builder.backgroundVariantFrequencyServiceFactory(backgroundFreqFactory);
+            }
         }
 
         return builder.shouldLoadOrpha2Gene(runConfiguration.useOrphanet)
                 .parallelism(dataSection.parallelism)
                 .build();
+    }
+
+    private GenomeBuild inferGenomeBuildFromExomiser() {
+        boolean couldProceedWithHg19 = exomiserResourcesAppearUsable(
+                dataSection.exomiserHg19DataDirectory,
+                dataSection.exomiserHg19Database,
+                dataSection.exomiserHg19ClinVarDatabase);
+        boolean couldProceedWithHg38 = exomiserResourcesAppearUsable(
+                dataSection.exomiserHg38DataDirectory,
+                dataSection.exomiserHg38Database,
+                dataSection.exomiserHg38ClinVarDatabase);
+
+        if (couldProceedWithHg38) {
+            //noinspection LoggingSimilarMessage
+            LOGGER.info("Genome build was inferred to {} based on provided Exomiser data resources", GenomeBuild.HG38);
+            return GenomeBuild.HG38; // Use hg38 even if both hg19 and hg38 are set.
+        } else if (couldProceedWithHg19) {
+            LOGGER.info("Genome build was inferred to {} based on provided Exomiser data resources", GenomeBuild.HG19);
+            return GenomeBuild.HG19;
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean exomiserResourcesAppearUsable(
+            Path exomiserDataDirectory,
+            Path exomiserAlleleDatabasePath,
+            Path exomiserClinVarDatabasePath
+    ) {
+        return exomiserDataDirectory != null || (exomiserAlleleDatabasePath != null && exomiserClinVarDatabasePath != null);
     }
 
     /**
@@ -272,10 +308,10 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
      * @throws LiricalDataException if one or both database paths are <code>null</code> or do not point to readable file.
      */
     private static ExomiserResources loadExomiserResources(
-            GenomeBuild genomeBuild,
-            Path exomiserDataDirectory,
-            Path exomiserAlleleDatabasePath,
-            Path exomiserClinVarDatabasePath
+        GenomeBuild genomeBuild,
+        Path exomiserDataDirectory,
+        Path exomiserAlleleDatabasePath,
+        Path exomiserClinVarDatabasePath
     ) throws LiricalDataException {
         // At the end of the function, we need to possess path to allele DB and ClinVar DB files.
         //
@@ -371,14 +407,11 @@ abstract class LiricalConfigurationCommand extends BaseCommand {
 
     protected abstract String getGenomeBuild();
 
-    protected GenomeBuild parseGenomeBuild(String genomeBuild) throws LiricalDataException {
-        Optional<GenomeBuild> genomeBuildOptional = GenomeBuild.parse(genomeBuild);
-        if (genomeBuildOptional.isEmpty())
-            throw new LiricalDataException("Unknown genome build: '" + genomeBuild + "'");
-        return genomeBuildOptional.get();
-    }
-
-    protected AnalysisOptions prepareAnalysisOptions(Lirical lirical, GenomeBuild genomeBuild, TranscriptDatabase transcriptDb) {
+    protected AnalysisOptions prepareAnalysisOptions(
+        Lirical lirical,
+        GenomeBuild genomeBuild,
+        TranscriptDatabase transcriptDb
+    ) {
         AnalysisOptions.Builder builder = AnalysisOptions.builder();
 
         // Genome build

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
@@ -36,7 +36,7 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--vcf"},
             description = "Path to a VCF file. This path has priority over any VCF files described in phenopacket.")
-    public String vcfPath;
+    public Path vcfPath;
 
     @Override
     protected String getGenomeBuild() {
@@ -49,7 +49,7 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
         // a greater priority
         SanitationInputs data = PhenopacketUtil.readPhenopacketData(phenopacketPath);
 
-        String vcf = vcfPath != null
+        Path vcf = vcfPath != null
                 ? vcfPath
                 : data.vcf();
 
@@ -64,12 +64,9 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
     @Override
     protected List<String> checkInput() {
         List<String> errors = super.checkInput();
-        if (genomeBuild == null && vcfPath != null) {
-            String msg = "The --vcf is set but --assembly is not specified. "
-                    + "Proceed either with genotype-aware analysis with both --vcf and --assembly options, "
-                    + "or run a phenotype-only analysis without the --vcf and --assembly options.";
-            errors.add(msg);
-        }
+        String vcfAndAssemblyCheckResult = checkVcfAndAssembly(vcfPath, genomeBuild);
+        if (vcfAndAssemblyCheckResult != null)
+            errors.add(vcfAndAssemblyCheckResult);
         return errors;
     }
 

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
@@ -21,8 +21,8 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: ${DEFAULT-VALUE}).")
-    public String genomeBuild = "hg38";
+            description = "Genome build (default: unset).")
+    public String genomeBuild = null;
 
     @CommandLine.Option(names = {"-p", "--phenopacket"},
             required = true,

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
@@ -5,6 +5,7 @@ import org.monarchinitiative.lirical.core.sanitize.SanitationInputs;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Run LIRICAL from a Phenopacket -- with or without accompanying VCF file.
@@ -58,6 +59,18 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
                 data.age(),
                 data.sex(),
                 vcf);
+    }
+
+    @Override
+    protected List<String> checkInput() {
+        List<String> errors = super.checkInput();
+        if (genomeBuild == null && vcfPath != null) {
+            String msg = "The --vcf is set but --assembly is not specified. "
+                    + "Proceed either with genotype-aware analysis with both --vcf and --assembly options, "
+                    + "or run a phenotype-only analysis without the --vcf and --assembly options.";
+            errors.add(msg);
+        }
+        return errors;
     }
 
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommand.java
@@ -21,7 +21,11 @@ public class PhenopacketCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: unset).")
+            description = {
+                    "Genome build.",
+                    "Leave unset to run in phenotype-only mode.",
+                    "Default: ${DEFAULT-VALUE}"
+            })
     public String genomeBuild = null;
 
     @CommandLine.Option(names = {"-p", "--phenopacket"},

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
@@ -24,7 +24,11 @@ public class PrioritizeCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: unset).")
+            description = {
+                    "Genome build.",
+                    "Leave unset to run in phenotype-only mode.",
+                    "Default: ${DEFAULT-VALUE}"
+            })
     public String genomeBuild = null;
 
     @CommandLine.Option(names = {"--vcf"},

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
@@ -75,4 +75,15 @@ public class PrioritizeCommand extends AbstractPrioritizeCommand {
         return new SanitationInputsDefault(sampleId, presentTerms, excludedTerms, age, sex, vcfPath);
     }
 
+    @Override
+    protected List<String> checkInput() {
+        List<String> errors = super.checkInput();
+        if (genomeBuild == null && vcfPath != null) {
+            String msg = "The --vcf is set but --assembly is not specified. "
+                    + "Proceed either with genotype-aware analysis with both --vcf and --assembly options, "
+                    + "or run a phenotype-only analysis without the --vcf and --assembly options.";
+            errors.add(msg);
+        }
+        return errors;
+    }
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
@@ -24,8 +24,8 @@ public class PrioritizeCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: ${DEFAULT-VALUE}).")
-    public String genomeBuild = "hg38";
+            description = "Genome build (default: unset).")
+    public String genomeBuild = null;
 
     @CommandLine.Option(names = {"--vcf"},
             description = "Path to VCF file (optional).")

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommand.java
@@ -3,6 +3,7 @@ package org.monarchinitiative.lirical.cli.cmd;
 import org.monarchinitiative.lirical.core.sanitize.SanitationInputs;
 import picocli.CommandLine;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +34,7 @@ public class PrioritizeCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--vcf"},
             description = "Path to VCF file (optional).")
-    public String vcfPath = null;
+    public Path vcfPath = null;
 
     @CommandLine.Option(names = {"--sample-id"},
             description = "Proband's identifier (default: ${DEFAULT-VALUE}).")
@@ -78,12 +79,9 @@ public class PrioritizeCommand extends AbstractPrioritizeCommand {
     @Override
     protected List<String> checkInput() {
         List<String> errors = super.checkInput();
-        if (genomeBuild == null && vcfPath != null) {
-            String msg = "The --vcf is set but --assembly is not specified. "
-                    + "Proceed either with genotype-aware analysis with both --vcf and --assembly options, "
-                    + "or run a phenotype-only analysis without the --vcf and --assembly options.";
-            errors.add(msg);
-        }
+        String vcfAndAssemblyCheckResult = checkVcfAndAssembly(vcfPath, genomeBuild);
+        if (vcfAndAssemblyCheckResult != null)
+            errors.add(vcfAndAssemblyCheckResult);
         return errors;
     }
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/SanitationInputsDefault.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/SanitationInputsDefault.java
@@ -2,6 +2,7 @@ package org.monarchinitiative.lirical.cli.cmd;
 
 import org.monarchinitiative.lirical.core.sanitize.SanitationInputs;
 
+import java.nio.file.Path;
 import java.util.List;
 
 record SanitationInputsDefault(
@@ -10,6 +11,6 @@ record SanitationInputsDefault(
         List<String> excludedHpoTerms,
         String age,
         String sex,
-        String vcf
+        Path vcf
 ) implements SanitationInputs {
 }

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
@@ -32,8 +32,8 @@ public class YamlCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: ${DEFAULT-VALUE}).")
-    public String genomeBuild = "hg38";
+            description = "Genome build (default: unset).")
+    public String genomeBuild = null;
 
     @Override
     protected String getGenomeBuild() {

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/YamlCommand.java
@@ -1,7 +1,7 @@
 package org.monarchinitiative.lirical.cli.cmd;
 
-import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.cli.yaml.YamlParser;
+import org.monarchinitiative.lirical.core.analysis.LiricalParseException;
 import org.monarchinitiative.lirical.core.sanitize.SanitationInputs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +32,11 @@ public class YamlCommand extends AbstractPrioritizeCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: unset).")
+            description = {
+                    "Genome build.",
+                    "Leave unset to run in phenotype-only mode.",
+                    "Default: ${DEFAULT-VALUE}"
+            })
     public String genomeBuild = null;
 
     @Override

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
@@ -34,11 +34,6 @@ public class PhenopacketsCommand extends OutputCommand {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PhenopacketsCommand.class);
 
-    @CommandLine.Option(names = {"--assembly"},
-            paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: unset).")
-    public String genomeBuild = null;
-
     @CommandLine.Parameters(
             paramLabel = "phenopacket file(s)",
             description = {
@@ -49,7 +44,7 @@ public class PhenopacketsCommand extends OutputCommand {
 
     @Override
     protected String getGenomeBuild() {
-        return genomeBuild;
+        return null;  // experimental phenopackets subcommand is phenotype-only
     }
 
     @Override
@@ -65,17 +60,10 @@ public class PhenopacketsCommand extends OutputCommand {
         }
 
         Lirical lirical;
-        Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
-        if (genomeBuild.isPresent()) {
-            LOGGER.debug("Using genome build {}", genomeBuild.get());
-        } else {
-            LOGGER.debug("Processing phenopackets in phenotype-only mode");
-        }
+        GenomeBuild genomeBuild = null;
         try {
-            LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
-
             // 1 - bootstrap the app
-            lirical = bootstrapLirical(genomeBuild.orElse(null));
+            lirical = bootstrapLirical(genomeBuild);
             LOGGER.info("Configured LIRICAL {}", lirical.version()
                     .map("v%s"::formatted)
                     .orElse(UNKNOWN_VERSION_PLACEHOLDER));
@@ -101,7 +89,7 @@ public class PhenopacketsCommand extends OutputCommand {
 
         // 3 - process phenopackets
         LOGGER.info("Processing phenopackets");
-        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild.orElse(null), runConfiguration.transcriptDb);
+        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild, runConfiguration.transcriptDb);
 
         try (LiricalAnalysisRunner analysisRunner = lirical.analysisRunner()) {
             for (SanitationResultsAndPath result : sanitationResults) {

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/cmd/experimental/PhenopacketsCommand.java
@@ -36,8 +36,8 @@ public class PhenopacketsCommand extends OutputCommand {
 
     @CommandLine.Option(names = {"--assembly"},
             paramLabel = "{hg19,hg38}",
-            description = "Genome build (default: ${DEFAULT-VALUE}).")
-    public String genomeBuild = "hg38";
+            description = "Genome build (default: unset).")
+    public String genomeBuild = null;
 
     @CommandLine.Parameters(
             paramLabel = "phenopacket file(s)",
@@ -65,14 +65,17 @@ public class PhenopacketsCommand extends OutputCommand {
         }
 
         Lirical lirical;
-        GenomeBuild genomeBuild;
+        Optional<GenomeBuild> genomeBuild = GenomeBuild.parse(getGenomeBuild());
+        if (genomeBuild.isPresent()) {
+            LOGGER.debug("Using genome build {}", genomeBuild.get());
+        } else {
+            LOGGER.debug("Processing phenopackets in phenotype-only mode");
+        }
         try {
-            genomeBuild = parseGenomeBuild(getGenomeBuild());
-            LOGGER.debug("Using genome build {}", genomeBuild);
             LOGGER.debug("Using {} transcripts", runConfiguration.transcriptDb);
 
             // 1 - bootstrap the app
-            lirical = bootstrapLirical(genomeBuild);
+            lirical = bootstrapLirical(genomeBuild.orElse(null));
             LOGGER.info("Configured LIRICAL {}", lirical.version()
                     .map("v%s"::formatted)
                     .orElse(UNKNOWN_VERSION_PLACEHOLDER));
@@ -98,7 +101,7 @@ public class PhenopacketsCommand extends OutputCommand {
 
         // 3 - process phenopackets
         LOGGER.info("Processing phenopackets");
-        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild, runConfiguration.transcriptDb);
+        AnalysisOptions analysisOptions = prepareAnalysisOptions(lirical, genomeBuild.orElse(null), runConfiguration.transcriptDb);
 
         try (LiricalAnalysisRunner analysisRunner = lirical.analysisRunner()) {
             for (SanitationResultsAndPath result : sanitationResults) {

--- a/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/yaml/YamlConfig.java
+++ b/lirical-cli/src/main/java/org/monarchinitiative/lirical/cli/yaml/YamlConfig.java
@@ -78,14 +78,7 @@ public class YamlConfig implements SanitationInputs {
         return sex;
     }
 
-    public String vcf() {
-        return vcf;
+    public Path vcf() {
+        return Path.of(vcf);
     }
-
-    public Optional<Path> vcfPath() {
-        return vcf == null ?
-                Optional.empty()
-                : Optional.of(Path.of(vcf));
-    }
-
 }

--- a/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/BaseCommandTest.java
+++ b/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/BaseCommandTest.java
@@ -1,0 +1,18 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import java.nio.file.Path;
+
+public class BaseCommandTest {
+
+    // `lirical-cli` directory.
+    protected static final Path LIRICAL_CLI_DIR = Path.of("").toAbsolutePath();
+    // Folder with example VCF, Phenopacket, and YAML inputs.
+    protected static final Path EXAMPLES_DIR = LIRICAL_CLI_DIR.resolve("src").resolve("examples");
+    protected static final Path VCF_FILE = EXAMPLES_DIR.resolve("LDS2.vcf.gz");
+
+    // Fake data directory.
+    protected static final Path DATA_DIR = LIRICAL_CLI_DIR.resolve("src").resolve("test").resolve("resources").resolve("data");
+    protected static final Path EXOMISER_HG19 = DATA_DIR.resolve("2406_hg19");
+    protected static final Path EXOMISER_HG38 = DATA_DIR.resolve("2406_hg38");
+
+}

--- a/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommandTest.java
+++ b/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/PhenopacketCommandTest.java
@@ -1,0 +1,84 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PhenopacketCommandTest extends BaseCommandTest{
+
+    protected static final Path PHENOPACKET = EXAMPLES_DIR.resolve("LDS2.v2.json");
+
+    private PhenopacketCommand cmd;
+
+    @BeforeEach
+    public void setUp() {
+        cmd = new PhenopacketCommand();
+    }
+
+    @Test
+    public void phenotypeOnlyRun() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.phenopacketPath = PHENOPACKET;
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+
+    @Test
+    public void genotypeAwareRunNeedsAssemblyAndExomiserDir() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.phenopacketPath = PHENOPACKET;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+        cmd.dataSection.exomiserHg38DataDirectory = EXOMISER_HG38;
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+    @Test
+    public void genotypeAwareRunNeedsAssemblyAndExomiserFiles() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.phenopacketPath = PHENOPACKET;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+        cmd.dataSection.exomiserHg38Database = EXOMISER_HG38.resolve("2406_hg38_variants.mv.db");
+        cmd.dataSection.exomiserHg38ClinVarDatabase = EXOMISER_HG38.resolve("2406_hg38_clinvar.mv.db");
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+    @Test
+    public void complainsWhenMissingAssemblyOrVcf() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.phenopacketPath = PHENOPACKET;
+        cmd.dataSection.exomiserHg38DataDirectory = EXOMISER_HG38;
+
+        cmd.genomeBuild = "hg38";
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "The --assembly is set but --vcf is not specified. Proceed either with genotype-aware analysis with both --vcf and --assembly options, or run a phenotype-only analysis without the --vcf and --assembly options."
+                )
+        );
+
+        cmd.genomeBuild = null;
+        cmd.vcfPath = VCF_FILE;
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "The --vcf is set but --assembly is not specified. Proceed either with genotype-aware analysis with both --vcf and --assembly options, or run a phenotype-only analysis without the --vcf and --assembly options."
+                )
+        );
+    }
+}

--- a/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommandTest.java
+++ b/lirical-cli/src/test/java/org/monarchinitiative/lirical/cli/cmd/PrioritizeCommandTest.java
@@ -1,0 +1,114 @@
+package org.monarchinitiative.lirical.cli.cmd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PrioritizeCommandTest extends BaseCommandTest {
+
+    private PrioritizeCommand cmd;
+
+    @BeforeEach
+    public void setUp() {
+        cmd = new PrioritizeCommand();
+    }
+
+    @Test
+    public void phenotypeOnlyRun() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+    @Test
+    public void genotypeAwareRunNeedsAssemblyAndExomiserDir() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+        cmd.dataSection.exomiserHg38DataDirectory = EXOMISER_HG38;
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+    @Test
+    public void genotypeAwareRunNeedsAssemblyAndExomiserFiles() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+        cmd.dataSection.exomiserHg38Database = EXOMISER_HG38.resolve("2406_hg38_variants.mv.db");
+        cmd.dataSection.exomiserHg38ClinVarDatabase = EXOMISER_HG38.resolve("2406_hg38_clinvar.mv.db");
+
+        List<String> checks = cmd.checkInput();
+
+        assertThat(checks, is(empty()));
+    }
+
+    @Test
+    public void complainsWhenMissingAssemblyOrVcf() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.dataSection.exomiserHg38DataDirectory = EXOMISER_HG38;
+
+        cmd.genomeBuild = "hg38";
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "The --assembly is set but --vcf is not specified. Proceed either with genotype-aware analysis with both --vcf and --assembly options, or run a phenotype-only analysis without the --vcf and --assembly options."
+                )
+        );
+
+        cmd.genomeBuild = null;
+        cmd.vcfPath = VCF_FILE;
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "The --vcf is set but --assembly is not specified. Proceed either with genotype-aware analysis with both --vcf and --assembly options, or run a phenotype-only analysis without the --vcf and --assembly options."
+                )
+        );
+    }
+
+    @Test
+    public void complainsWhenMissingExomiserDataDir() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "Genome build set to HG38 but Exomiser resources are unset"
+                )
+        );
+    }
+
+    @Test
+    public void complainsWhenMissingExomiserFiles() {
+        cmd.dataSection.liricalDataDirectory = DATA_DIR;
+        cmd.genomeBuild = "hg38";
+        cmd.vcfPath = VCF_FILE;
+
+        cmd.dataSection.exomiserHg38Database = EXOMISER_HG38.resolve("2406_hg38_variants.mv.db");
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "Genome build set to HG38 but Exomiser resources are unset"
+                )
+        );
+
+        cmd.dataSection.exomiserHg38Database = null;
+        cmd.dataSection.exomiserHg38ClinVarDatabase = EXOMISER_HG38.resolve("2406_hg38_clinvar.mv.db");
+        assertThat(cmd.checkInput(), hasSize(1));
+        assertThat(
+                cmd.checkInput(), hasItems(
+                        "Genome build set to HG38 but Exomiser resources are unset"
+                )
+        );
+    }
+}

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
@@ -20,12 +20,14 @@ public interface AnalysisOptions {
     }
 
     /**
-     * @return genomic build that should be used in this analysis.
+     * @return genomic build that should be used in this analysis
+     * or {@code null} if the analysis should be run in phenotype only mode.
      */
     GenomeBuild genomeBuild();
 
     /**
-     * @return the transcript database that should be used in this analysis.
+     * @return the transcript database that should be used in this analysis
+     * or {@code null} if the analysis should be run in phenotype only mode.
      */
     TranscriptDatabase transcriptDatabase();
 
@@ -86,7 +88,7 @@ public interface AnalysisOptions {
     class Builder {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(Builder.class);
-        private GenomeBuild genomeBuild = GenomeBuild.HG38;
+        private GenomeBuild genomeBuild = null;
         private TranscriptDatabase transcriptDatabase = TranscriptDatabase.REFSEQ;
         private final Set<DiseaseDatabase> diseaseDatabases = new HashSet<>(List.of(DiseaseDatabase.OMIM, DiseaseDatabase.DECIPHER));
         private Set<TermId> targetDiseases = null;  // null = test all diseases
@@ -101,10 +103,6 @@ public interface AnalysisOptions {
         }
 
         public Builder genomeBuild(GenomeBuild genomeBuild) {
-            if (genomeBuild == null) {
-                LOGGER.warn("Cannot set genome build to `null`. Retaining {}", this.genomeBuild);
-                return this;
-            }
             this.genomeBuild = genomeBuild;
             return this;
         }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/AnalysisOptions.java
@@ -20,14 +20,13 @@ public interface AnalysisOptions {
     }
 
     /**
-     * @return genomic build that should be used in this analysis
-     * or {@code null} if the analysis should be run in phenotype only mode.
+     * @return genome build to use in the analysis
+     * or {@code null} to run a phenotype-only analysis.
      */
     GenomeBuild genomeBuild();
 
     /**
-     * @return the transcript database that should be used in this analysis
-     * or {@code null} if the analysis should be run in phenotype only mode.
+     * @return the transcript database that should be used in this analysis.
      */
     TranscriptDatabase transcriptDatabase();
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/LiricalAnalysisRunnerImpl.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/LiricalAnalysisRunnerImpl.java
@@ -53,7 +53,7 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
     public AnalysisResults run(AnalysisData data, AnalysisOptions options) throws LiricalAnalysisException {
         Map<TermId, List<Gene2Genotype>> diseaseToGenotype = groupDiseasesByGene(data.genes());
 
-        GenotypeLikelihoodRatio glr = configureGenotypeLikelihoodRatio(
+        GenotypeLikelihoodRatio genotypeLikelihoodRatio = configureGenotypeLikelihoodRatio(
                 options.genomeBuild(),
                 options.variantDeleteriousnessThreshold(),
                 options.defaultVariantBackgroundFrequency(),
@@ -65,7 +65,7 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
                 .parallel() // why not?
                 .filter(prepareDiseaseFilter(options.diseaseDatabases(), options.targetDiseases()))
                 .peek(d -> progressReporter.log())
-                .map(disease -> analyzeDisease(glr, disease, data, options, diseaseToGenotype.getOrDefault(disease.id(), List.of())))
+                .map(disease -> analyzeDisease(genotypeLikelihoodRatio, disease, data, options, diseaseToGenotype))
                 .flatMap(Optional::stream);
 
         try {
@@ -110,11 +110,11 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
     }
 
     private Optional<TestResult> analyzeDisease(
-            GenotypeLikelihoodRatio glr,
+            GenotypeLikelihoodRatio genotypeLikelihoodRatio,
             HpoDisease disease,
             AnalysisData analysisData,
             AnalysisOptions options,
-            List<Gene2Genotype> genotypes
+            Map<TermId, List<Gene2Genotype>> diseaseToGenotype
     ) {
         Optional<Double> pretestOptional = options.pretestDiseaseProbability().pretestProbability(disease.id());
         if (pretestOptional.isEmpty()) {
@@ -127,13 +127,15 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
         List<LrWithExplanation> observed = observedPhenotypesLikelihoodRatios(analysisData.presentPhenotypeTerms(), idg);
         List<LrWithExplanation> excluded = excludedPhenotypesLikelihoodRatios(analysisData.negatedPhenotypeTerms(), idg);
 
-        // The GT LR stays `null` if we run phenotype only (`glr==null`).
+        // The GT LR stays `null` if no genotype data is available.
         GenotypeLrWithExplanation bestGenotypeLr = null;
-        if (glr != null) {
-            // The variant/genotype data is available for the individual
+        if (genotypeLikelihoodRatio != null && !diseaseToGenotype.isEmpty()) {
+            // The variant/genotype data is available for the individual,
+            // and we do *not* run a phenotype-only analysis.
             boolean noPredictedDeleteriousVariantsWereFound = true;
-            for (Gene2Genotype g2g : genotypes) { // Find the gene with the best LR match
-                GenotypeLrWithExplanation candidate = glr.evaluateGenotype(analysisData.sampleId(), g2g, disease.modesOfInheritance());
+            for (Gene2Genotype g2g : diseaseToGenotype.getOrDefault(disease.id(), List.of())) {
+                // Find the gene with the best LR match
+                GenotypeLrWithExplanation candidate = genotypeLikelihoodRatio.evaluateGenotype(analysisData.sampleId(), g2g, disease.modesOfInheritance());
                 bestGenotypeLr = takeNonNullOrGreaterLr(bestGenotypeLr, candidate);
 
                 if (!options.includeDiseasesWithNoDeleteriousVariants()) {
@@ -196,18 +198,14 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
             boolean strict
     ) {
         if (genomeBuild == null)
+            // We're running a phenotype-only analysis.
             return null;
 
-        Optional<GenotypeLikelihoodRatio> genotypeLikelihoodRatio = bgFreqFactory.forGenomeBuild(genomeBuild, defaultVariantBackgroundFrequency)
+        return bgFreqFactory.forGenomeBuild(genomeBuild, defaultVariantBackgroundFrequency)
                 .map(bgFreqService -> {
                     GenotypeLikelihoodRatio.Options options = new GenotypeLikelihoodRatio.Options(deleteriousnessThreshold, strict);
                     return new GenotypeLikelihoodRatio(bgFreqService, options);
-                });
-        if (genotypeLikelihoodRatio.isEmpty())
-            LOGGER.warn("Could not configure genotype likelihood ratio for {}", genomeBuild);
-
-        return genotypeLikelihoodRatio
-                .orElse(null);
+                }).orElse(null);
     }
 
     @Override

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/LiricalAnalysisRunnerImpl.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/analysis/impl/LiricalAnalysisRunnerImpl.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.lirical.core.analysis.impl;
 
 import org.monarchinitiative.lirical.core.analysis.*;
-import org.monarchinitiative.lirical.core.analysis.LiricalAnalysisException;
 import org.monarchinitiative.lirical.core.likelihoodratio.*;
 import org.monarchinitiative.lirical.core.model.Gene2Genotype;
 import org.monarchinitiative.lirical.core.model.GenesAndGenotypes;
@@ -30,9 +29,11 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
     private final PhenotypeLikelihoodRatio phenotypeLrEvaluator;
     private final ExecutorService pool;
 
-    public static LiricalAnalysisRunnerImpl of(PhenotypeService phenotypeService,
-                                               BackgroundVariantFrequencyServiceFactory backgroundVariantFrequencyServiceFactory,
-                                               int parallelism) {
+    public static LiricalAnalysisRunnerImpl of(
+            PhenotypeService phenotypeService,
+            BackgroundVariantFrequencyServiceFactory backgroundVariantFrequencyServiceFactory,
+            int parallelism
+    ) {
         return new LiricalAnalysisRunnerImpl(phenotypeService,
                 backgroundVariantFrequencyServiceFactory,
                 parallelism);
@@ -52,20 +53,19 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
     public AnalysisResults run(AnalysisData data, AnalysisOptions options) throws LiricalAnalysisException {
         Map<TermId, List<Gene2Genotype>> diseaseToGenotype = groupDiseasesByGene(data.genes());
 
-        Optional<GenotypeLikelihoodRatio> genotypeLikelihoodRatio = configureGenotypeLikelihoodRatio(options.genomeBuild(),
+        GenotypeLikelihoodRatio glr = configureGenotypeLikelihoodRatio(
+                options.genomeBuild(),
                 options.variantDeleteriousnessThreshold(),
                 options.defaultVariantBackgroundFrequency(),
-                options.useStrictPenalties());
-        if (genotypeLikelihoodRatio.isEmpty()) {
-            throw new LiricalAnalysisException("Cannot configure genotype LR for %s".formatted(options.genomeBuild()));
-        }
+                options.useStrictPenalties()
+        );
 
         ProgressReporter progressReporter = new ProgressReporter(1_000, "diseases");
         Stream<TestResult> testResultStream = phenotypeService.diseases().hpoDiseases()
                 .parallel() // why not?
                 .filter(prepareDiseaseFilter(options.diseaseDatabases(), options.targetDiseases()))
                 .peek(d -> progressReporter.log())
-                .map(disease -> analyzeDisease(genotypeLikelihoodRatio.get(), disease, data, options, diseaseToGenotype))
+                .map(disease -> analyzeDisease(glr, disease, data, options, diseaseToGenotype.getOrDefault(disease.id(), List.of())))
                 .flatMap(Optional::stream);
 
         try {
@@ -101,7 +101,7 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
         for (Gene2Genotype gene : genes) {
             Collection<TermId> diseaseIds = geneToDisease.getOrDefault(gene.geneId().id(), List.of());
             for (TermId diseaseId : diseaseIds) {
-                diseaseToGenotype.computeIfAbsent(diseaseId, k -> new LinkedList<>())
+                diseaseToGenotype.computeIfAbsent(diseaseId, k -> new ArrayList<>())
                         .add(gene);
             }
         }
@@ -109,11 +109,13 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
         return diseaseToGenotype;
     }
 
-    private Optional<TestResult> analyzeDisease(GenotypeLikelihoodRatio genotypeLikelihoodRatio,
-                                                HpoDisease disease,
-                                                AnalysisData analysisData,
-                                                AnalysisOptions options,
-                                                Map<TermId, List<Gene2Genotype>> diseaseToGenotype) {
+    private Optional<TestResult> analyzeDisease(
+            GenotypeLikelihoodRatio glr,
+            HpoDisease disease,
+            AnalysisData analysisData,
+            AnalysisOptions options,
+            List<Gene2Genotype> genotypes
+    ) {
         Optional<Double> pretestOptional = options.pretestDiseaseProbability().pretestProbability(disease.id());
         if (pretestOptional.isEmpty()) {
             LOGGER.warn("Missing pretest probability for {} ({})", disease.diseaseName(), disease.id());
@@ -121,19 +123,17 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
         }
         double pretestProbability = pretestOptional.get();
 
-        List<Gene2Genotype> genotypes = diseaseToGenotype.getOrDefault(disease.id(), List.of());
-
         InducedDiseaseGraph idg = InducedDiseaseGraph.create(disease, phenotypeService.hpo());
         List<LrWithExplanation> observed = observedPhenotypesLikelihoodRatios(analysisData.presentPhenotypeTerms(), idg);
         List<LrWithExplanation> excluded = excludedPhenotypesLikelihoodRatios(analysisData.negatedPhenotypeTerms(), idg);
 
-        // The GT LR stays `null` if no genotype data is available.
+        // The GT LR stays `null` if we run phenotype only (`glr==null`).
         GenotypeLrWithExplanation bestGenotypeLr = null;
-        if (!diseaseToGenotype.isEmpty()) {
+        if (glr != null) {
             // The variant/genotype data is available for the individual
             boolean noPredictedDeleteriousVariantsWereFound = true;
             for (Gene2Genotype g2g : genotypes) { // Find the gene with the best LR match
-                GenotypeLrWithExplanation candidate = genotypeLikelihoodRatio.evaluateGenotype(analysisData.sampleId(), g2g, disease.modesOfInheritance());
+                GenotypeLrWithExplanation candidate = glr.evaluateGenotype(analysisData.sampleId(), g2g, disease.modesOfInheritance());
                 bestGenotypeLr = takeNonNullOrGreaterLr(bestGenotypeLr, candidate);
 
                 if (!options.includeDiseasesWithNoDeleteriousVariants()) {
@@ -189,15 +189,25 @@ public class LiricalAnalysisRunnerImpl implements LiricalAnalysisRunner {
                 : candidate;
     }
 
-    private Optional<GenotypeLikelihoodRatio> configureGenotypeLikelihoodRatio(GenomeBuild genomeBuild,
-                                                                     float deleteriousnessThreshold,
-                                                                     double defaultVariantBackgroundFrequency,
-                                                                     boolean strict) {
-        return bgFreqFactory.forGenomeBuild(genomeBuild, defaultVariantBackgroundFrequency)
+    private GenotypeLikelihoodRatio configureGenotypeLikelihoodRatio(
+            GenomeBuild genomeBuild,
+            float deleteriousnessThreshold,
+            double defaultVariantBackgroundFrequency,
+            boolean strict
+    ) {
+        if (genomeBuild == null)
+            return null;
+
+        Optional<GenotypeLikelihoodRatio> genotypeLikelihoodRatio = bgFreqFactory.forGenomeBuild(genomeBuild, defaultVariantBackgroundFrequency)
                 .map(bgFreqService -> {
                     GenotypeLikelihoodRatio.Options options = new GenotypeLikelihoodRatio.Options(deleteriousnessThreshold, strict);
                     return new GenotypeLikelihoodRatio(bgFreqService, options);
                 });
+        if (genotypeLikelihoodRatio.isEmpty())
+            LOGGER.warn("Could not configure genotype likelihood ratio for {}", genomeBuild);
+
+        return genotypeLikelihoodRatio
+                .orElse(null);
     }
 
     @Override

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/GenomeBuild.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/model/GenomeBuild.java
@@ -14,6 +14,9 @@ public enum GenomeBuild {
     private static final Pattern HG = Pattern.compile("hg(?<release>\\d{2})");
 
     public static Optional<GenomeBuild> parse(String payload) {
+        if (payload == null)
+            return Optional.empty();
+
         Matcher grchMatcher = GRCH.matcher(payload);
         if (grchMatcher.matches()) {
             return switch (grchMatcher.group("release")) {

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/BaseInputSanitizer.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/BaseInputSanitizer.java
@@ -69,14 +69,13 @@ abstract class BaseInputSanitizer implements InputSanitizer {
         }
     }
 
-    protected void checkVcf(String vcf, SanitizedInputs sanitized, List<SanityIssue> issues) {
+    protected void checkVcf(Path vcf, SanitizedInputs sanitized, List<SanityIssue> issues) {
         if (vcf != null) {
-            Path path = Path.of(vcf);
-            if (Files.isRegularFile(path) && Files.isReadable(path)) {
-                sanitized.setVcf(path);
+            if (Files.isRegularFile(vcf) && Files.isReadable(vcf)) {
+                sanitized.setVcf(vcf);
             } else {
                 issues.add(SanityIssue.error(
-                        "VCF path is set but %s does not point to a readable file".formatted(path.toAbsolutePath()),
+                        "VCF path is set but %s does not point to a readable file".formatted(vcf.toAbsolutePath()),
                         "Update the path or the file permissions"));
             }
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/MinimalInputSanitizer.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/MinimalInputSanitizer.java
@@ -5,7 +5,6 @@ import org.monarchinitiative.lirical.core.model.Sex;
 import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 
 import java.time.Period;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitationInputs.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitationInputs.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.lirical.core.sanitize;
 
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ public interface SanitationInputs {
     String sex();
 
     /**
-     * @return a string with the path of the VCF file with variants or {@code null} if not available.
+     * @return a path with the path of the VCF file with variants or {@code null} if not available.
      */
-    String vcf();
+    Path vcf();
 }

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitationResultNotRun.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitationResultNotRun.java
@@ -30,7 +30,7 @@ class SanitationResultNotRun implements SanitationResult {
                 inputs.excludedHpoTerms().stream().map(TermId::of).toList(),
                 parseAge(inputs.age()),
                 Sex.valueOf(inputs.sex()),
-                inputs.vcf() == null ? null : Path.of(inputs.vcf())
+                inputs.vcf() == null ? null : inputs.vcf()
         );
     }
 

--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitizedInputs.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/sanitize/SanitizedInputs.java
@@ -35,7 +35,7 @@ public final class SanitizedInputs {
                     Age age,
                     Sex sex,
                     Path vcf) {
-        this.sampleId = sampleId;
+        this.sampleId = sampleId; // nullable
         this.presentHpoTerms.addAll(present);
         this.excludedHpoTerms.addAll(excluded);
         this.age = age; // nullable

--- a/lirical-core/src/test/java/org/monarchinitiative/lirical/core/model/GenomeBuildTest.java
+++ b/lirical-core/src/test/java/org/monarchinitiative/lirical/core/model/GenomeBuildTest.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.lirical.core.model;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -24,5 +25,10 @@ public class GenomeBuildTest {
         Optional<GenomeBuild> optionalGb = GenomeBuild.parse(payload);
         assertThat(optionalGb.isPresent(), equalTo(true));
         assertThat(optionalGb.get(), equalTo(expected));
+    }
+
+    @Test
+    public void parsingNullReturnsAnEmptyOptional() {
+        assertThat(GenomeBuild.parse(null).isEmpty(), equalTo(true));
     }
 }

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketData.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketData.java
@@ -6,6 +6,7 @@ import org.monarchinitiative.lirical.core.model.GenotypedVariant;
 import org.monarchinitiative.lirical.core.sanitize.SanitationInputs;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
+import java.nio.file.Path;
 import java.time.Period;
 import java.util.List;
 import java.util.Objects;
@@ -25,7 +26,7 @@ public class PhenopacketData implements SanitationInputs {
     private final String age;
     private final String sex;
     private final List<TermId> diseaseIds;
-    private final String vcfPath;
+    private final Path vcfPath;
 
     PhenopacketData(String genomeAssembly,
                     String sampleId,
@@ -35,7 +36,7 @@ public class PhenopacketData implements SanitationInputs {
                     String sex,
                     List<TermId> diseaseIds,
                     List<GenotypedVariant> variants,
-                    String vcfPath) {
+                    Path vcfPath) {
         this.genomeAssembly = genomeAssembly;
         this.sampleId = Objects.requireNonNull(sampleId);
         this.hpoTerms = Objects.requireNonNull(hpoTerms);
@@ -103,7 +104,7 @@ public class PhenopacketData implements SanitationInputs {
     }
 
     @Override
-    public String vcf() {
+    public Path vcf() {
         return vcfPath;
     }
 

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1Importer.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1Importer.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -93,6 +94,7 @@ class PhenopacketV1Importer implements PhenopacketImporter {
                 .toList();
 
         Path vcfPath = firstVcf.map(HtsFile::getUri)
+                .map(URI::create)
                 .map(Path::of)
                 .orElse(null);
 

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1Importer.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1Importer.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,8 @@ class PhenopacketV1Importer implements PhenopacketImporter {
                 .flatMap(Optional::stream)
                 .toList();
 
-        String vcfPath = firstVcf.map(HtsFile::getUri)
+        Path vcfPath = firstVcf.map(HtsFile::getUri)
+                .map(Path::of)
                 .orElse(null);
 
         return new PhenopacketData(genomeBuild,

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2Importer.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2Importer.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -80,7 +81,8 @@ class PhenopacketV2Importer implements PhenopacketImporter {
         Optional<File> firstVcf = phenopacket.getFilesList().stream()
                 .filter(file -> "vcf".equalsIgnoreCase(file.getFileAttributesOrDefault("fileFormat", "")))
                 .findFirst();
-        String firstVcfPath = firstVcf.map(File::getUri)
+        Path firstVcfPath = firstVcf.map(File::getUri)
+                .map(Path::of)
                 .orElse(null);
         String genomeAssembly = firstVcf.map(f -> f.getFileAttributesOrDefault("genomeAssembly", null))
                 .orElse(null);

--- a/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2Importer.java
+++ b/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2Importer.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,6 +83,7 @@ class PhenopacketV2Importer implements PhenopacketImporter {
                 .filter(file -> "vcf".equalsIgnoreCase(file.getFileAttributesOrDefault("fileFormat", "")))
                 .findFirst();
         Path firstVcfPath = firstVcf.map(File::getUri)
+                .map(URI::create)
                 .map(Path::of)
                 .orElse(null);
         String genomeAssembly = firstVcf.map(f -> f.getFileAttributesOrDefault("genomeAssembly", null))

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/BBS1Test.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/BBS1Test.java
@@ -49,7 +49,7 @@ public class BBS1Test {
     public void testGetVcfPhenopacket() {
         Path vcfPath = DATA.vcf();
         assertThat(vcfPath, is(notNullValue()));
-        assertThat(vcfPath, equalTo(Path.of("file:/path/to/examples/BBS1.vcf")));
+        assertThat(vcfPath, equalTo(Path.of("/path/to/examples/BBS1.vcf")));
     }
 
     @Test

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/BBS1Test.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/BBS1Test.java
@@ -47,9 +47,9 @@ public class BBS1Test {
 
     @Test
     public void testGetVcfPhenopacket() {
-        String vcfPath = DATA.vcf();
+        Path vcfPath = DATA.vcf();
         assertThat(vcfPath, is(notNullValue()));
-        assertThat(vcfPath, equalTo("file:/path/to/examples/BBS1.vcf"));
+        assertThat(vcfPath, equalTo(Path.of("file:/path/to/examples/BBS1.vcf")));
     }
 
     @Test

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1ImporterTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1ImporterTest.java
@@ -137,7 +137,7 @@ public class PhenopacketV1ImporterTest {
 
     @Test
     public void testGetVcfFile() {
-        assertEquals(Path.of("file:/home/user/example.vcf"), data.vcf());
+        assertEquals(Path.of("/home/user/example.vcf"), data.vcf());
 
         Optional<String> assembly = data.genomeAssembly();
         assertThat(assembly.isPresent(), equalTo(true));

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1ImporterTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV1ImporterTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -136,7 +137,7 @@ public class PhenopacketV1ImporterTest {
 
     @Test
     public void testGetVcfFile() {
-        assertEquals("file:/home/user/example.vcf", data.vcf());
+        assertEquals(Path.of("file:/home/user/example.vcf"), data.vcf());
 
         Optional<String> assembly = data.genomeAssembly();
         assertThat(assembly.isPresent(), equalTo(true));

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2ImporterTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2ImporterTest.java
@@ -12,6 +12,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -49,7 +50,7 @@ public class PhenopacketV2ImporterTest {
 
         assertThat(data.diseaseIds().stream().map(TermId::getValue).toList(), hasItems("OMIM:191100"));
 
-        assertThat(data.vcf(), equalTo("file:/path/to/Pfeiffer.vcf"));
+        assertThat(data.vcf(), equalTo(Path.of("file:/path/to/Pfeiffer.vcf")));
 
         assertThat(data.genomeAssembly().isPresent(), equalTo(true));
         assertThat(data.genomeAssembly().get(), equalTo("GRCh37"));

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2ImporterTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketV2ImporterTest.java
@@ -50,7 +50,7 @@ public class PhenopacketV2ImporterTest {
 
         assertThat(data.diseaseIds().stream().map(TermId::getValue).toList(), hasItems("OMIM:191100"));
 
-        assertThat(data.vcf(), equalTo(Path.of("file:/path/to/Pfeiffer.vcf")));
+        assertThat(data.vcf(), equalTo(Path.of("/path/to/Pfeiffer.vcf")));
 
         assertThat(data.genomeAssembly().isPresent(), equalTo(true));
         assertThat(data.genomeAssembly().get(), equalTo("GRCh37"));

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/BBS1.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/BBS1.json
@@ -122,7 +122,7 @@
     "symbol": "BBS1"
   }],
   "htsFiles": [{
-    "uri": "file:///path/to/examples/BBS1.vcf",
+    "uri": "file:/path/to/examples/BBS1.vcf",
     "description": "BBS1 sample",
     "htsFormat": "VCF",
     "genomeAssembly": "GRCh37",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/BBS1.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/BBS1.json
@@ -122,7 +122,7 @@
     "symbol": "BBS1"
   }],
   "htsFiles": [{
-    "uri": "file:/path/to/examples/BBS1.vcf",
+    "uri": "file:///path/to/examples/BBS1.vcf",
     "description": "BBS1 sample",
     "htsFormat": "VCF",
     "genomeAssembly": "GRCh37",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v1.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v1.json
@@ -216,7 +216,7 @@
     "genomeAssembly": "GRCh37",
     "individualToSampleIdentifiers": {
     },
-    "uri": "file:///path/to/Pfeiffer.vcf"
+    "uri": "file:/path/to/Pfeiffer.vcf"
   }],
   "metaData": {
     "createdBy": "HPO:lccarmody",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v1.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v1.json
@@ -216,7 +216,7 @@
     "genomeAssembly": "GRCh37",
     "individualToSampleIdentifiers": {
     },
-    "uri": "file:/path/to/Pfeiffer.vcf"
+    "uri": "file:///path/to/Pfeiffer.vcf"
   }],
   "metaData": {
     "createdBy": "HPO:lccarmody",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.json
@@ -136,7 +136,7 @@
     "excluded": false
   }],
   "files": [{
-    "uri": "file:///path/to/Pfeiffer.vcf",
+    "uri": "file:/path/to/Pfeiffer.vcf",
     "fileAttributes": {
       "genomeAssembly": "GRCh37",
       "fileFormat": "vcf",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.json
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.json
@@ -136,7 +136,7 @@
     "excluded": false
   }],
   "files": [{
-    "uri": "file:/path/to/Pfeiffer.vcf",
+    "uri": "file:///path/to/Pfeiffer.vcf",
     "fileAttributes": {
       "genomeAssembly": "GRCh37",
       "fileFormat": "vcf",

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.yaml
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.yaml
@@ -94,7 +94,7 @@ diseases:
     label: "TUBEROUS SCLEROSIS 1; TSC1"
   excluded: false
 files:
-- uri: "file:///path/to/Pfeiffer.vcf"
+- uri: "file:/path/to/Pfeiffer.vcf"
   fileAttributes:
     genomeAssembly: "GRCh37"
     fileFormat: "vcf"

--- a/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.yaml
+++ b/lirical-io/src/test/resources/org/monarchinitiative/lirical/io/analysis/pfeiffer.v2.yaml
@@ -94,7 +94,7 @@ diseases:
     label: "TUBEROUS SCLEROSIS 1; TSC1"
   excluded: false
 files:
-- uri: "file:/path/to/Pfeiffer.vcf"
+- uri: "file:///path/to/Pfeiffer.vcf"
   fileAttributes:
     genomeAssembly: "GRCh37"
     fileFormat: "vcf"


### PR DESCRIPTION
The PR fixes an inconsistency in CLI that prevented running a phenotype-only analysis without providing path to Exomiser resources. This was incorrect, since Exomiser resources would end up being not used anyway.

The PR changes the default `--assembly` from `hg38` to `null`, effectively unsetting it by default. A phenotype-only analysis is run if none of `--assembly`, `--vcf`, and Exomiser resources are provided. A genotype-aware analysis is performed if both `--assembly` and `--vcf` options are provided. Any other configuration raises an error.