### PR TITLE
fix #683

### DIFF
--- a/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
+++ b/lirical-core/src/main/java/org/monarchinitiative/lirical/core/likelihoodratio/GenotypeLikelihoodRatio.java
@@ -220,8 +220,8 @@ public class GenotypeLikelihoodRatio {
                     returnvalue,
                     maxInheritanceMode,
                     lambda_background,
-                    B,
                     D,
+                    B,
                     observedWeightedDeleteriousVariantCount);
         }
     }


### PR DESCRIPTION
Fixed the issue where the order of parameters D and B was reversed when calling GenotypeLrWithExplanation.explanation