### PR TITLE
Include runtime-scoped dependencies in the distribution

### DIFF
--- a/lirical-cli/pom.xml
+++ b/lirical-cli/pom.xml
@@ -91,7 +91,7 @@
                                     <goal>copy-dependencies</goal>
                                 </goals>
                                 <configuration>
-                                    <includeScope>compile</includeScope>
+                                    <includeScope>runtime</includeScope>
                                     <outputDirectory>${project.build.directory}/lib</outputDirectory>
                                     <overWriteReleases>false</overWriteReleases>
                                     <overWriteSnapshots>false</overWriteSnapshots>

--- a/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketImportUtilTest.java
+++ b/lirical-io/src/test/java/org/monarchinitiative/lirical/io/analysis/PhenopacketImportUtilTest.java
@@ -1,0 +1,24 @@
+package org.monarchinitiative.lirical.io.analysis;
+
+import org.junit.jupiter.api.Test;
+import org.phenopackets.schema.v2.Phenopacket;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class PhenopacketImportUtilTest {
+
+    @Test
+    public void readPhenopacket_protobuf() throws IOException, PhenopacketImportException {
+        Phenopacket phenopacket;
+        try (InputStream is = PhenopacketImportUtilTest.class.getResourceAsStream("pfeiffer.v2.pb")) {
+            phenopacket = PhenopacketImportUtil.readPhenopacket(is, Phenopacket.class);
+        }
+        assertThat(phenopacket.getId(), equalTo("pfeiffer-phenopacket"));
+        assertThat(phenopacket.getSubject().getId(), equalTo("II:3/Family 2"));
+    }
+
+}


### PR DESCRIPTION
We also need to include `runtime`-scoped dependencies in the distribution, not only `compile`-scoped dependencies.

Fixes #695 